### PR TITLE
March onboarding polish (Free): discovery, accessibility, success flow, analytics

### DIFF
--- a/assets/js/admin/booster-onboarding.js
+++ b/assets/js/admin/booster-onboarding.js
@@ -54,6 +54,14 @@
 			);
 
 			$( document ).on(
+				'keydown',
+				'.booster-goal-tile, .booster-blueprint-tile',
+				function(e) {
+					self.handleTileKeyboardNav( e, $( this ) );
+				}
+			);
+
+			$( document ).on(
 				'click',
 				'.booster-blueprint-tile',
 				function() {
@@ -125,6 +133,37 @@
 			);
 		},
 
+		handleTileKeyboardNav: function(e, tile) {
+			var keyCode = e.keyCode || e.which;
+
+			if (keyCode === 13 || keyCode === 32) {
+				e.preventDefault();
+				tile.trigger( 'click' );
+				return;
+			}
+
+			if (keyCode !== 37 && keyCode !== 38 && keyCode !== 39 && keyCode !== 40) {
+				return;
+			}
+
+			e.preventDefault();
+
+			var selector = tile.hasClass( 'booster-blueprint-tile' ) ? '.booster-blueprint-tile:visible' : '.booster-goal-tile:visible';
+			var visibleTiles = this.modal.find( selector );
+			var currentIndex = visibleTiles.index( tile );
+			var nextIndex = currentIndex;
+
+			if (keyCode === 37 || keyCode === 38) {
+				nextIndex = currentIndex - 1;
+			} else if (keyCode === 39 || keyCode === 40) {
+				nextIndex = currentIndex + 1;
+			}
+
+			if (nextIndex >= 0 && nextIndex < visibleTiles.length) {
+				visibleTiles.eq( nextIndex ).focus();
+			}
+		},
+
 		setupAccessibility: function() {
 			var self = this;
 
@@ -189,14 +228,61 @@
 			if (typeof boosterOnboarding.appliedGoals !== 'undefined') {
 				boosterOnboarding.appliedGoals.forEach(
 					function(goalId) {
-						$( '.booster-goal-tile[data-goal="' + goalId + '"] .applied-badge' ).show();
+						$( '.booster-goal-tile[data-goal="' + goalId + '"]' )
+							.attr( 'aria-pressed', 'true' )
+							.find( '.applied-badge' )
+							.show();
 					}
+				);
+			}
+		},
+
+		markGoalApplied: function(goalId) {
+			if ( ! goalId) {
+				return;
+			}
+
+			if (typeof boosterOnboarding.appliedGoals === 'undefined' || ! Array.isArray( boosterOnboarding.appliedGoals )) {
+				boosterOnboarding.appliedGoals = [];
+			}
+
+			if (boosterOnboarding.appliedGoals.indexOf( goalId ) === -1) {
+				boosterOnboarding.appliedGoals.push( goalId );
+			}
+
+			$( '.booster-goal-tile[data-goal="' + goalId + '"]' )
+				.attr( 'aria-pressed', 'true' )
+				.find( '.applied-badge' )
+				.show();
+		},
+
+		markBlueprintApplied: function(blueprintId) {
+			if ( ! blueprintId) {
+				return;
+			}
+
+			$( '.booster-blueprint-tile[data-blueprint="' + blueprintId + '"]' )
+				.attr( 'aria-pressed', 'true' )
+				.find( '.applied-badge' )
+				.show();
+
+			if (boosterOnboarding.blueprints && boosterOnboarding.blueprints[blueprintId] && boosterOnboarding.blueprints[blueprintId].goal_keys) {
+				boosterOnboarding.blueprints[blueprintId].goal_keys.forEach(
+					function(goalId) {
+						this.markGoalApplied( goalId );
+					}.bind( this )
 				);
 			}
 		},
 
 		updateProgressIndicator: function(step) {
 			$( '.progress-step' ).removeClass( 'active completed' );
+			var stepMap = {
+				choose: 1,
+				review: 2,
+				complete: 3
+			};
+			this.modal.find( '.booster-progress-indicator' ).attr( 'aria-valuenow', stepMap[step] || 1 );
 
 			if (step === 'choose') {
 				$( '.progress-step[data-step="choose"]' ).addClass( 'active' );
@@ -275,6 +361,8 @@
 			this.currentGoal = goalId;
 			this.currentBlueprint = null;
 			var goal         = boosterOnboarding.goals[goalId];
+			$( '.booster-goal-tile' ).attr( 'aria-pressed', 'false' );
+			$( '.booster-goal-tile[data-goal="' + goalId + '"]' ).attr( 'aria-pressed', 'true' );
 
 			$( '#review-goal-title' ).text( goal.title );
 
@@ -321,6 +409,8 @@
 			this.currentBlueprint = blueprintId;
 			this.currentGoal = null;
 			var blueprint = boosterOnboarding.blueprints[blueprintId];
+			$( '.booster-blueprint-tile' ).attr( 'aria-pressed', 'false' );
+			$( '.booster-blueprint-tile[data-blueprint="' + blueprintId + '"]' ).attr( 'aria-pressed', 'true' );
 
 			$( '#review-goal-title' ).text( blueprint.title );
 
@@ -442,19 +532,29 @@
 			$( '#pro-note-container' ).hide();
 			$( '.primary-cta-button' ).hide();
 
+			if (data.next_steps && data.next_steps.length > 0) {
+				var nextStepsList = $( '#next-steps-list' );
+				nextStepsList.empty();
+				data.next_steps.forEach(
+					function(step) {
+						if (typeof step === 'object' && step.href && step.label) {
+							nextStepsList.append( '<li><a href="' + step.href + '">' + step.label + '</a></li>' );
+						} else {
+							nextStepsList.append( '<li>' + step + '</li>' );
+						}
+					}
+				);
+				$( '#next-steps-container' ).show();
+			}
+
 			if (data.next_step_text && data.next_step_link) {
 				$( '#primary-cta-text' ).text( data.next_step_text );
 				$( '.primary-cta-button' ).attr( 'href', data.next_step_link ).show();
 			}
 
 			this.showSuccessScreen();
-
-			setTimeout(
-				function() {
-					window.location.reload();
-				},
-				3000
-			);
+			this.markGoalApplied( this.currentGoal );
+			this.logEvent( 'goal_completed', { goal_id: this.currentGoal } );
 		},
 
 		showBlueprintSuccessScreen: function(data) {
@@ -465,7 +565,11 @@
 				nextStepsList.empty();
 				data.next_steps.forEach(
 					function(step) {
-						nextStepsList.append( '<li><a href="' + step.href + '">' + step.label + '</a></li>' );
+						if (step.href && step.label) {
+							nextStepsList.append( '<li><a href="' + step.href + '">' + step.label + '</a></li>' );
+						} else {
+							nextStepsList.append( '<li>' + step + '</li>' );
+						}
 					}
 				);
 				$( '#next-steps-container' ).show();
@@ -488,13 +592,7 @@
 			}
 
 			this.showSuccessScreen();
-
-			setTimeout(
-				function() {
-					window.location.reload();
-				},
-				3000
-			);
+			this.markBlueprintApplied( this.currentBlueprint );
 		},
 
 		undoGoal: function(goalId) {
@@ -592,7 +690,7 @@
 			// Clear search when switching modes or closing modal.
 			$( document ).on(
 				'click',
-				'.segment-button, .booster-modal-close, .booster-modal-overlay',
+				'.segment-button, .booster-modal-close, .booster-modal-overlay, .pick-another-button, .back-button',
 				function() {
 					searchInput.val( '' );
 					clearButton.hide();

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 == Changelog ==
 
+= March 2026 Onboarding Release (Upcoming) =
+
+* Improved onboarding discoverability so store owners can find the right setup goal faster.
+* Improved keyboard accessibility and modal navigation for a smoother setup experience.
+* Improved completion flow with clearer success states and practical next-step guidance.
+* Added richer local onboarding event tracking (goal selected/applied/completed/undone) for product decision-making.
+* Improved first-win coverage checks for key onboarding goal paths.
+
 = 7.11.2 27/02/2026 =
 
 * Security hardening update across key request and file-handling flows.

--- a/includes/admin/class-booster-onboarding.php
+++ b/includes/admin/class-booster-onboarding.php
@@ -433,6 +433,24 @@ if ( ! class_exists( 'Booster_Onboarding' ) ) :
 
 			update_option( $this->option_key, $onboarding_state );
 
+			$this->log_onboarding_event(
+				'goal_applied',
+				array(
+					'goal_id'          => $goal_id,
+					'modules_enabled'  => array_column( $goal['modules'], 'id' ),
+					'snapshot_created' => $create_snapshot,
+				)
+			);
+
+			$this->log_onboarding_event(
+				'goal_completed',
+				array(
+					'goal_id'             => $goal_id,
+					'is_first_goal'       => $is_first_win,
+					'first_win_check_met' => $this->check_first_win( $goal_id ),
+				)
+			);
+
 			$next_step_link = '';
 			if ( isset( $goal['next_step_link'] ) ) {
 				$next_step_link = admin_url( $goal['next_step_link'] . wp_create_nonce( 'wcj-cat-nonce' ) );
@@ -443,8 +461,75 @@ if ( ! class_exists( 'Booster_Onboarding' ) ) :
 				'message'        => __( 'Goal applied successfully!', 'woocommerce-jetpack' ),
 				'next_step_text' => isset( $goal['next_step_text'] ) ? $goal['next_step_text'] : '',
 				'next_step_link' => $next_step_link,
+				'next_steps'     => $this->get_goal_next_steps( $goal_id ),
 				'first_win'      => $is_first_win,
 			);
+		}
+
+		/**
+		 * Get goal-specific next-step guidance for success states.
+		 *
+		 * @param string $goal_id Goal ID.
+		 *
+		 * @return array
+		 */
+		private function get_goal_next_steps( $goal_id ) {
+			$steps = array(
+				'grow_sales'               => array(
+					__( 'Visit a product page to verify live sales notifications are visible.', 'woocommerce-jetpack' ),
+					__( 'Adjust notification timing and styling to match your brand.', 'woocommerce-jetpack' ),
+				),
+				'work_smarter'             => array(
+					__( 'Open your orders list to confirm sequential numbering is enabled.', 'woocommerce-jetpack' ),
+					__( 'Set your preferred order number format and prefix.', 'woocommerce-jetpack' ),
+				),
+				'go_global'                => array(
+					__( 'Add exchange rates for your target markets.', 'woocommerce-jetpack' ),
+					__( 'Test currency switching on storefront pages.', 'woocommerce-jetpack' ),
+				),
+				'professional_invoices'    => array(
+					__( 'Generate a test order to confirm PDF invoices are attached.', 'woocommerce-jetpack' ),
+					__( 'Customize invoice logo and footer text for your store.', 'woocommerce-jetpack' ),
+				),
+				'boost_conversions_free'   => array(
+					__( 'Enable add-ons on a top-selling product first.', 'woocommerce-jetpack' ),
+					__( 'Verify related products are showing on product pages.', 'woocommerce-jetpack' ),
+				),
+				'better_checkout_basics'   => array(
+					__( 'Review checkout field labels and ordering for clarity.', 'woocommerce-jetpack' ),
+					__( 'Run a test checkout to confirm the updated flow.', 'woocommerce-jetpack' ),
+				),
+				'store_essentials_quick'   => array(
+					__( 'Confirm new orders are using sequential numbering.', 'woocommerce-jetpack' ),
+					__( 'Add one global product tab with key purchase info.', 'woocommerce-jetpack' ),
+				),
+				'recover_lost_sales_goal'  => array(
+					__( 'Review abandonment timing and email trigger settings.', 'woocommerce-jetpack' ),
+					__( 'Send a test recovery email and validate links.', 'woocommerce-jetpack' ),
+				),
+				'b2b_store'                => array(
+					__( 'Validate role-based pricing and gateway rules with a test user.', 'woocommerce-jetpack' ),
+					__( 'Configure a first B2B-only coupon to confirm restrictions.', 'woocommerce-jetpack' ),
+				),
+				'intl_Store'               => array(
+					__( 'Verify currency display by country selection in storefront.', 'woocommerce-jetpack' ),
+					__( 'Check exchange rates and update any market-specific values.', 'woocommerce-jetpack' ),
+				),
+				'merchant_getting_started' => array(
+					__( 'Add one required product input field to a sample product.', 'woocommerce-jetpack' ),
+					__( 'Confirm checkout custom info appears as expected.', 'woocommerce-jetpack' ),
+				),
+				'merchant_aov_increase'    => array(
+					__( 'Generate a sample coupon and test URL coupon behavior.', 'woocommerce-jetpack' ),
+					__( 'Preview sale flash badges on discounted products.', 'woocommerce-jetpack' ),
+				),
+				'merchant_run_their_store_efficiently' => array(
+					__( 'Run a sample export to validate data columns.', 'woocommerce-jetpack' ),
+					__( 'Review admin product list columns for daily workflow fit.', 'woocommerce-jetpack' ),
+				),
+			);
+
+			return isset( $steps[ $goal_id ] ) ? $steps[ $goal_id ] : array();
 		}
 
 		/**
@@ -751,6 +836,14 @@ if ( ! class_exists( 'Booster_Onboarding' ) ) :
 
 			update_option( $this->option_key, $onboarding_state );
 
+			$this->log_onboarding_event(
+				'goal_undone',
+				array(
+					'goal_id'           => $goal_id,
+					'snapshot_restored' => true,
+				)
+			);
+
 			return array(
 				'success' => true,
 				'message' => __( 'Goal undone successfully!', 'woocommerce-jetpack' ),
@@ -796,6 +889,9 @@ if ( ! class_exists( 'Booster_Onboarding' ) ) :
 				case 'order_numbers_enabled':
 					return 'yes' === get_option( 'wcj_order_numbers_enabled', 'no' );
 
+				case 'wcj_order_numbers_enabled':
+					return 'yes' === get_option( 'wcj_order_numbers_enabled', 'no' );
+
 				case 'extra_currency_added':
 					$current_currency = get_woocommerce_currency();
 					return ( 'EUR' !== $current_currency && get_option( 'wcj_currency_EUR' ) ) ||
@@ -824,6 +920,10 @@ if ( ! class_exists( 'Booster_Onboarding' ) ) :
 
 				case 'wcj_export_enabled':
 					return 'yes' === get_option( 'wcj_export_enabled', 'no' );
+
+				case 'wcj_cart_abandonment_enabled':
+				case 'cart_abandonment_enabled':
+					return 'yes' === get_option( 'wcj_cart_abandonment_enabled', 'no' );
 
 				default:
 					return false;

--- a/includes/admin/onboarding-map.php
+++ b/includes/admin/onboarding-map.php
@@ -205,6 +205,8 @@ return array(
 			),
 		),
 		'first_win_check' => 'wcj_cart_abandonment_enabled',
+		'next_step_text'  => __( 'Configure cart recovery emails', 'woocommerce-jetpack' ),
+		'next_step_link'  => 'admin.php?page=wcj-plugins&tab=jetpack&wcj-cat=cart_and_checkout&section=cart_abandonment&wcj-cat-nonce=',
 	),
 	'b2b_store'                            => array(
 		'title'           => __( 'B2B Store', 'woocommerce-jetpack' ),

--- a/includes/admin/views/onboarding-modal.php
+++ b/includes/admin/views/onboarding-modal.php
@@ -29,7 +29,7 @@ $onboarding_map = include WCJ_FREE_PLUGIN_PATH . '/includes/admin/onboarding-map
 				</button>
 			</div>
 
-			<div class="booster-progress-indicator" aria-label="<?php esc_attr_e( 'Progress', 'woocommerce-jetpack' ); ?>">
+			<div class="booster-progress-indicator" role="progressbar" aria-label="<?php esc_attr_e( 'Progress', 'woocommerce-jetpack' ); ?>" aria-valuenow="1" aria-valuemin="1" aria-valuemax="3">
 				<div class="progress-step active" data-step="choose">
 					<span class="step-number">1</span>
 					<span class="step-label"><?php esc_html_e( 'Choose', 'woocommerce-jetpack' ); ?></span>
@@ -67,7 +67,7 @@ $onboarding_map = include WCJ_FREE_PLUGIN_PATH . '/includes/admin/onboarding-map
 				</div>
 				<div class="booster-goals-grid">
 					<?php foreach ( $onboarding_map as $goal_id => $goal ) : ?>
-						<div class="booster-goal-tile booster-tile" data-goal="<?php echo esc_attr( $goal_id ); ?>">
+						<div class="booster-goal-tile booster-tile" data-goal="<?php echo esc_attr( $goal_id ); ?>" role="button" tabindex="0" aria-pressed="false" aria-label="<?php echo esc_attr( $goal['title'] ); ?>">
 							<div class="goal-icon tile-icon">
 								<?php echo wp_kses_post( $goal['svg_icon'] ); ?>
 							</div>
@@ -111,7 +111,7 @@ $onboarding_map = include WCJ_FREE_PLUGIN_PATH . '/includes/admin/onboarding-map
 
 					foreach ( $blueprints as $blueprint_id => $blueprint ) :
 						?>
-						<div class="booster-blueprint-tile booster-tile" data-blueprint="<?php echo esc_attr( $blueprint_id ); ?>">
+						<div class="booster-blueprint-tile booster-tile" data-blueprint="<?php echo esc_attr( $blueprint_id ); ?>" role="button" tabindex="0" aria-pressed="false" aria-label="<?php echo esc_attr( $blueprint['title'] ); ?>">
 							<div class="blueprint-icon tile-icon">
 								<?php echo wp_kses_post( $blueprint['svg_icon'] ); ?>
 							</div>

--- a/readme.txt
+++ b/readme.txt
@@ -347,6 +347,13 @@ No. Onboarding analytics are local-only (apply/undo/mode views) to improve the e
 
 == Changelog ==
 
+= March 2026 Onboarding Release (Upcoming) =
+* Easier first-time setup: goal discovery and selection flow is clearer and easier to navigate.
+* Better accessibility: improved keyboard navigation and progress feedback in onboarding modal screens.
+* Clearer success guidance: after applying a goal, store owners now see practical next steps to keep momentum.
+* Better onboarding quality signals: expanded local-only onboarding event tracking for internal product decisions.
+* Reliability improvement: completed first-win mapping coverage for onboarding goal outcomes.
+
 = 7.11.2 - 27/02/2026 =
 * Security hardening update across key request and file-handling flows.
 * Improved authorization and validation checks in checkout-related file actions.


### PR DESCRIPTION
﻿## Customer outcome summary
This March onboarding polish makes it easier for merchants to get to first value quickly:
- Faster goal discovery and clearer selection in onboarding.
- Better keyboard usability and accessibility semantics.
- Clearer completion state with practical next steps after goal apply.
- Better local onboarding telemetry for product-quality decisions.

## What changed (by area)
### 1) Onboarding discovery + flow UX
- Improved onboarding modal interaction flow (goal/blueprint selection and completion state updates).
- Refined in-modal completion behavior so users can continue setup intentionally.

### 2) Accessibility improvements
- Improved onboarding modal semantics and ARIA attributes for progress and interactive tiles.
- Improved keyboard navigation handling for goal/blueprint tiles.

### 3) Success-state clarity
- Added richer goal-specific next-step guidance in onboarding responses.
- Added missing next-step metadata for cart recovery goal path.

### 4) Analytics and operational visibility (local only)
- Added onboarding lifecycle event logging for goal applied/completed/undone events.
- Added metadata payloads (goal id, modules enabled, snapshot state) to improve internal analysis quality.

### 5) Release-note quality
- Added merchant-facing March onboarding entries in:
  - `changelog.txt`
  - `readme.txt` changelog section

## What did NOT change (out of scope)
- No Booster Plus changes.
- No shipping zones 2/3 fixes.
- No order-number gateway/HPOS compatibility track changes.
- No packing-slip refund logic changes.
- No broad non-onboarding refactors.

## Risks / rollback notes
### Risk areas
- Onboarding modal interaction behavior.
- Goal apply/undo state transitions and telemetry payload shape.

### Rollback
- Revert this PR merge commit to return to pre-polish onboarding behavior.
- No schema migrations are introduced.

## How to test (Booster team checklist)
### Upgrade path
- [ ] Upgrade from latest security/public Free build to this branch build.
- [ ] Confirm no fatal errors/notices and onboarding remains limited to Booster admin contexts.

### Apply / Undo
- [ ] Apply representative goals with snapshot enabled.
- [ ] Undo applied goals and verify state restoration.
- [ ] Re-apply goals after undo and verify stable behavior.

### Search + keyboard accessibility
- [ ] Validate goal search filter + clear + no-results state.
- [ ] Validate keyboard-only tile navigation (Tab/Shift+Tab, arrows, Enter/Space).
- [ ] Validate Escape close and focus behavior.

### Success / next-step flow
- [ ] Confirm success screen remains usable (no forced interruption).
- [ ] Confirm next-step guidance and CTA links appear where expected.
- [ ] Confirm "Pick another goal" returns cleanly to selection.

### Presets / hub / filters integration
- [ ] Apply a blueprint and confirm included goals reflect applied state.
- [ ] Verify Getting Started hub and module filters still behave correctly.

### Regression smoke
- [ ] Check browser console for onboarding/dashboard JS errors.
- [ ] Run core cart/checkout/admin smoke flow.

## Repo-specific testing differences (Free vs Elite)
- This PR (Free) includes Blueprints flow validation and segmented onboarding mode behavior.
- Elite PR additionally validates license-step and elite-welcome-specific onboarding paths.

## Related
- Companion Elite PR in `booster-elite-for-woocommerce` for Session 1 March onboarding polish.
