### PR TITLE
v7.11.4

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 == Changelog ==
 
+= 7.11.4 - 14/03/2026 =
+* Normalized in-plugin upsell routing so generic compare-first prompts route to /free-vs-elite/ while explicit buy/pricing CTAs stay on /buy-booster/.
+* Kept upgrade-block comparison buttons and other ambiguous/tag-first docs/features/about assists on their current destinations while separating account, support, update, and download routes from generic sales flows.
+* Normalized Booster in-plugin source and UTM tagging across the scoped admin surfaces.
+* Confirmed no direct-checkout plugin CTA was introduced in this release candidate.
+* WooCommerce 10.5.3 Tested
+* WordPress 6.9.1 Tested
+
 = 7.11.3 - 11/03/2026 =
 * Improved goal discovery and blueprint selection flow for a faster setup experience.
 * Added clearer next-step instructions and goal-specific metadata for cart recovery and completion states.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,11 +1,11 @@
 == Changelog ==
 
-= 7.11.4 - 14/03/2026 =
+= 7.11.4 - 18/03/2026 =
 * Normalized in-plugin upsell routing so generic compare-first prompts route to /free-vs-elite/ while explicit buy/pricing CTAs stay on /buy-booster/.
 * Kept upgrade-block comparison buttons and other ambiguous/tag-first docs/features/about assists on their current destinations while separating account, support, update, and download routes from generic sales flows.
 * Normalized Booster in-plugin source and UTM tagging across the scoped admin surfaces.
 * Confirmed no direct-checkout plugin CTA was introduced in this release candidate.
-* WooCommerce 10.5.3 Tested
+* WooCommerce 10.6.1 Tested
 * WordPress 6.9.1 Tested
 
 = 7.11.3 - 11/03/2026 =

--- a/includes/admin/class-wc-settings-jetpack.php
+++ b/includes/admin/class-wc-settings-jetpack.php
@@ -105,7 +105,18 @@ if ( ! class_exists( 'WC_Settings_Jetpack' ) ) :
 			}
 			$class = 'notice notice-info';
 			/* translators: %s: search term */
-			$message      = sprintf( __( 'You\'re using Booster free version. To unlock more features please consider <a target="_blank" href="%s">Upgrade Booster to unlock this feature</a>.', 'woocommerce-jetpack' ), 'https://booster.io/buy-booster/' );
+			$message      = sprintf(
+				__( 'You\'re using Booster free version. To unlock more features please consider <a target="_blank" href="%s">Upgrade Booster to unlock this feature</a>.', 'woocommerce-jetpack' ),
+				esc_url(
+					wcj_build_commercial_url(
+						'compare',
+						array(
+							'campaign' => 'generic_upsell',
+							'content'  => 'free_version_notice__compare',
+						)
+					)
+				)
+			);
 			$booster_icon = '<span class="wcj-booster-logo"></span>';
 			?>
 				<style>
@@ -171,7 +182,7 @@ if ( ! class_exists( 'WC_Settings_Jetpack' ) ) :
 							</a>
 						</div>
 						<div class="sub-circle">
-							<a href="https://booster.io/my-account/booster-contact/" target="_blank">
+							<a href="<?php echo esc_url( wcj_build_commercial_url( 'account', array( 'path' => 'my-account/booster-contact/', 'campaign' => 'account', 'content' => 'premium_support_circle__account' ) ) ); ?>" target="_blank">
 								<div class="form_label">
 									<label>Booster Elite Premium Support (4 hours - 24 hours response)</label>
 									<div class="ic_list"><img src="<?php echo esc_url( $sec_link ); ?>/assets/images/support-24-h-w.png"></div>
@@ -929,7 +940,7 @@ if ( ! class_exists( 'WC_Settings_Jetpack' ) ) :
 						</div>
 					</div>
 					<div class="wcj-btn-main">
-						<a href="https://booster.io/buy-booster/" class="wcj-button" target="_blank"><?php esc_html_e( 'Get Booster Elite', 'woocommerce-jetpack' ); ?></a>
+						<a href="<?php echo esc_url( wcj_build_commercial_url( 'account', array( 'path' => 'my-account/', 'campaign' => 'account', 'content' => 'my_account_header__account' ) ) ); ?>" class="wcj-button" target="_blank"><?php esc_html_e( 'Get Booster Elite', 'woocommerce-jetpack' ); ?></a>
 					</div>
 				</div>
 				<div class="wcj-body-sec-part-main">
@@ -1009,7 +1020,7 @@ if ( ! class_exists( 'WC_Settings_Jetpack' ) ) :
 										<span><img src="<?php echo esc_url( wcj_plugin_url() ) . '/assets/images/down-arw.png'; ?>"></span>
 									</div>
 									<div class="wcj-panel">
-										<p><?php esc_html_e( 'You can see all the features at ', 'woocommerce-jetpack' ); ?><a href="https://booster.io/about/" target="_blank"><?php esc_html_e( 'About Booster', 'woocommerce-jetpack' ); ?></a><?php esc_html_e( ' page.', 'woocommerce-jetpack' ); ?></p>
+										<p><?php esc_html_e( 'You can see all the features at ', 'woocommerce-jetpack' ); ?><a href="<?php echo esc_url( wcj_build_commercial_url( 'assist', array( 'path' => 'about/', 'campaign' => 'generic_upsell', 'content' => 'my_account_faq_features__assist' ) ) ); ?>" target="_blank"><?php esc_html_e( 'About Booster', 'woocommerce-jetpack' ); ?></a><?php esc_html_e( ' page.', 'woocommerce-jetpack' ); ?></p>
 									</div>
 								</div>
 								<div class="wcj-additional-que">
@@ -1145,7 +1156,7 @@ if ( ! class_exists( 'WC_Settings_Jetpack' ) ) :
 				<li><?php esc_html_e( '+ More configuration options for payments and shipping', 'woocommerce-jetpack' ); ?></li>
 			</ul>
 			<div class="wcj-btn-main">
-				<a href="https://booster.io/buy-booster/" class="wcj-button" target="_blank"><?php esc_html_e( 'Upgrade to Booster Elite', 'woocommerce-jetpack' ); ?></a>
+				<a href="<?php echo esc_url( wcj_build_commercial_url( 'buy', array( 'campaign' => 'dashboard_header', 'content' => 'feature_promo_box__buy' ) ) ); ?>" class="wcj-button" target="_blank"><?php esc_html_e( 'Upgrade to Booster Elite', 'woocommerce-jetpack' ); ?></a>
 			</div>
 		</div>
 	</div>

--- a/includes/admin/class-wc-settings-jetpack.php
+++ b/includes/admin/class-wc-settings-jetpack.php
@@ -103,9 +103,9 @@ if ( ! class_exists( 'WC_Settings_Jetpack' ) ) :
 			if ( 'woocommerce-jetpack.php' !== basename( WCJ_FREE_PLUGIN_FILE ) ) {
 				return;
 			}
-			$class = 'notice notice-info';
-			/* translators: %s: search term */
-			$message      = sprintf(
+			$class   = 'notice notice-info';
+			$message = sprintf(
+				/* translators: %s: URL to Booster upgrade page */
 				__( 'You\'re using Booster free version. To unlock more features please consider <a target="_blank" href="%s">Upgrade Booster to unlock this feature</a>.', 'woocommerce-jetpack' ),
 				esc_url(
 					wcj_build_commercial_url(
@@ -182,7 +182,20 @@ if ( ! class_exists( 'WC_Settings_Jetpack' ) ) :
 							</a>
 						</div>
 						<div class="sub-circle">
-							<a href="<?php echo esc_url( wcj_build_commercial_url( 'account', array( 'path' => 'my-account/booster-contact/', 'campaign' => 'account', 'content' => 'premium_support_circle__account' ) ) ); ?>" target="_blank">
+							<a href="
+							<?php
+							echo esc_url(
+								wcj_build_commercial_url(
+									'account',
+									array(
+										'path'     => 'my-account/booster-contact/',
+										'campaign' => 'account',
+										'content'  => 'premium_support_circle__account',
+									)
+								)
+							);
+							?>
+										" target="_blank">
 								<div class="form_label">
 									<label>Booster Elite Premium Support (4 hours - 24 hours response)</label>
 									<div class="ic_list"><img src="<?php echo esc_url( $sec_link ); ?>/assets/images/support-24-h-w.png"></div>
@@ -267,11 +280,11 @@ if ( ! class_exists( 'WC_Settings_Jetpack' ) ) :
 				foreach ( $this->module_statuses as $module_status ) {
 					if ( isset( $module_status['id'] ) && isset( $module_status['default'] ) ) {
 						if ( 'yes' === wcj_get_option( $module_status['id'], $module_status['default'] ) ) {
-							$active++;
+							++$active;
 						} elseif ( wcj_is_module_deprecated( $module_status['id'], true ) ) {
 							continue;
 						}
-						$all++;
+						++$all;
 					}
 				}
 
@@ -640,7 +653,7 @@ if ( ! class_exists( 'WC_Settings_Jetpack' ) ) :
 							continue;
 						}
 					}
-					$total_modules++;
+					++$total_modules;
 					$html .= '<tr id="' . $the_feature['id'] . '" class="' . $this->active( wcj_get_option( $the_feature['id'] ) ) . '">';
 					$html .= '<th scope="row" class="check-column">';
 					$html .= '<label class="screen-reader-text" for="' . $the_feature['id'] . '">' . $the_feature['desc'] . '</label>';
@@ -876,7 +889,6 @@ if ( ! class_exists( 'WC_Settings_Jetpack' ) ) :
 					echo wp_kses_post( $lines . '<br>' );
 				}
 			}
-
 		}
 
 		/**
@@ -940,7 +952,20 @@ if ( ! class_exists( 'WC_Settings_Jetpack' ) ) :
 						</div>
 					</div>
 					<div class="wcj-btn-main">
-						<a href="<?php echo esc_url( wcj_build_commercial_url( 'account', array( 'path' => 'my-account/', 'campaign' => 'account', 'content' => 'my_account_header__account' ) ) ); ?>" class="wcj-button" target="_blank"><?php esc_html_e( 'Get Booster Elite', 'woocommerce-jetpack' ); ?></a>
+						<a href="
+						<?php
+						echo esc_url(
+							wcj_build_commercial_url(
+								'account',
+								array(
+									'path'     => 'my-account/',
+									'campaign' => 'account',
+									'content'  => 'my_account_header__account',
+								)
+							)
+						);
+						?>
+									" class="wcj-button" target="_blank"><?php esc_html_e( 'Get Booster Elite', 'woocommerce-jetpack' ); ?></a>
 					</div>
 				</div>
 				<div class="wcj-body-sec-part-main">
@@ -1020,7 +1045,20 @@ if ( ! class_exists( 'WC_Settings_Jetpack' ) ) :
 										<span><img src="<?php echo esc_url( wcj_plugin_url() ) . '/assets/images/down-arw.png'; ?>"></span>
 									</div>
 									<div class="wcj-panel">
-										<p><?php esc_html_e( 'You can see all the features at ', 'woocommerce-jetpack' ); ?><a href="<?php echo esc_url( wcj_build_commercial_url( 'assist', array( 'path' => 'about/', 'campaign' => 'generic_upsell', 'content' => 'my_account_faq_features__assist' ) ) ); ?>" target="_blank"><?php esc_html_e( 'About Booster', 'woocommerce-jetpack' ); ?></a><?php esc_html_e( ' page.', 'woocommerce-jetpack' ); ?></p>
+										<p><?php esc_html_e( 'You can see all the features at ', 'woocommerce-jetpack' ); ?><a href="
+										<?php
+										echo esc_url(
+											wcj_build_commercial_url(
+												'assist',
+												array(
+													'path' => 'about/',
+													'campaign' => 'generic_upsell',
+													'content' => 'my_account_faq_features__assist',
+												)
+											)
+										);
+										?>
+											" target="_blank"><?php esc_html_e( 'About Booster', 'woocommerce-jetpack' ); ?></a><?php esc_html_e( ' page.', 'woocommerce-jetpack' ); ?></p>
 									</div>
 								</div>
 								<div class="wcj-additional-que">
@@ -1156,7 +1194,19 @@ if ( ! class_exists( 'WC_Settings_Jetpack' ) ) :
 				<li><?php esc_html_e( '+ More configuration options for payments and shipping', 'woocommerce-jetpack' ); ?></li>
 			</ul>
 			<div class="wcj-btn-main">
-				<a href="<?php echo esc_url( wcj_build_commercial_url( 'buy', array( 'campaign' => 'dashboard_header', 'content' => 'feature_promo_box__buy' ) ) ); ?>" class="wcj-button" target="_blank"><?php esc_html_e( 'Upgrade to Booster Elite', 'woocommerce-jetpack' ); ?></a>
+				<a href="
+					<?php
+					echo esc_url(
+						wcj_build_commercial_url(
+							'buy',
+							array(
+								'campaign' => 'dashboard_header',
+								'content'  => 'feature_promo_box__buy',
+							)
+						)
+					);
+					?>
+				" class="wcj-button" target="_blank"><?php esc_html_e( 'Upgrade to Booster Elite', 'woocommerce-jetpack' ); ?></a>
 			</div>
 		</div>
 	</div>
@@ -1164,7 +1214,6 @@ if ( ! class_exists( 'WC_Settings_Jetpack' ) ) :
 					<?php
 				}
 		}
-
 	}
 
 endif;

--- a/includes/admin/onboarding-blueprints.php
+++ b/includes/admin/onboarding-blueprints.php
@@ -40,7 +40,7 @@ return array(
 		),
 		'pro_note'        => array(
 			'label' => __( 'Sequences & coupon automation available in Elite — Compare →', 'woocommerce-jetpack' ),
-			'href'  => 'https://booster.io/buy-booster/#compare',
+			'href'  => wcj_build_commercial_url( 'compare', array( 'campaign' => 'onboarding_blueprint', 'content' => 'recover_lost_sales__compare' ) ),
 		),
 		'success_message' => __( 'Great! Cart abandonment recovery is now active.', 'woocommerce-jetpack' ),
 	),
@@ -68,7 +68,7 @@ return array(
 		),
 		'pro_note'        => array(
 			'label' => __( 'Conditional add-ons & fees in Elite — Compare →', 'woocommerce-jetpack' ),
-			'href'  => 'https://booster.io/buy-booster/#compare',
+			'href'  => wcj_build_commercial_url( 'compare', array( 'campaign' => 'onboarding_blueprint', 'content' => 'boost_aov__compare' ) ),
 		),
 		'success_message' => __( 'Nice! Your store can now offer add-ons and show related products.', 'woocommerce-jetpack' ),
 	),
@@ -100,7 +100,7 @@ return array(
 		),
 		'pro_note'        => array(
 			'label' => __( 'Geo-price & currency controls in Elite — Compare →', 'woocommerce-jetpack' ),
-			'href'  => 'https://booster.io/buy-booster/#compare',
+			'href'  => wcj_build_commercial_url( 'compare', array( 'campaign' => 'onboarding_blueprint', 'content' => 'sell_internationally__compare' ) ),
 		),
 		'success_message' => __( 'Perfect! Your store is now ready for international customers.', 'woocommerce-jetpack' ),
 	),

--- a/includes/admin/onboarding-blueprints.php
+++ b/includes/admin/onboarding-blueprints.php
@@ -40,7 +40,13 @@ return array(
 		),
 		'pro_note'        => array(
 			'label' => __( 'Sequences & coupon automation available in Elite — Compare →', 'woocommerce-jetpack' ),
-			'href'  => wcj_build_commercial_url( 'compare', array( 'campaign' => 'onboarding_blueprint', 'content' => 'recover_lost_sales__compare' ) ),
+			'href'  => wcj_build_commercial_url(
+				'compare',
+				array(
+					'campaign' => 'onboarding_blueprint',
+					'content'  => 'recover_lost_sales__compare',
+				)
+			),
 		),
 		'success_message' => __( 'Great! Cart abandonment recovery is now active.', 'woocommerce-jetpack' ),
 	),
@@ -68,7 +74,13 @@ return array(
 		),
 		'pro_note'        => array(
 			'label' => __( 'Conditional add-ons & fees in Elite — Compare →', 'woocommerce-jetpack' ),
-			'href'  => wcj_build_commercial_url( 'compare', array( 'campaign' => 'onboarding_blueprint', 'content' => 'boost_aov__compare' ) ),
+			'href'  => wcj_build_commercial_url(
+				'compare',
+				array(
+					'campaign' => 'onboarding_blueprint',
+					'content'  => 'boost_aov__compare',
+				)
+			),
 		),
 		'success_message' => __( 'Nice! Your store can now offer add-ons and show related products.', 'woocommerce-jetpack' ),
 	),
@@ -100,7 +112,13 @@ return array(
 		),
 		'pro_note'        => array(
 			'label' => __( 'Geo-price & currency controls in Elite — Compare →', 'woocommerce-jetpack' ),
-			'href'  => wcj_build_commercial_url( 'compare', array( 'campaign' => 'onboarding_blueprint', 'content' => 'sell_internationally__compare' ) ),
+			'href'  => wcj_build_commercial_url(
+				'compare',
+				array(
+					'campaign' => 'onboarding_blueprint',
+					'content'  => 'sell_internationally__compare',
+				)
+			),
 		),
 		'success_message' => __( 'Perfect! Your store is now ready for international customers.', 'woocommerce-jetpack' ),
 	),

--- a/includes/admin/wcj-settings-dashboard.php
+++ b/includes/admin/wcj-settings-dashboard.php
@@ -116,7 +116,7 @@ if ( isset( $GLOBALS['wcj_getting_started_hub'] ) ) {
 							</div>
 							<div class="wcj-dash-sing-icon-dtl">
 								<h4><?php esc_html_e( 'Generate Site Key', 'woocommerce-jetpack' ); ?></h4>
-								<p><?php esc_html_e( 'Add Booster to your website - ', 'woocommerce-jetpack' ); ?><a target="_blank" href="https://booster.io/my-account/downloads/"><?php esc_html_e( 'Generate Key', 'woocommerce-jetpack' ); ?></a></p>
+								<p><?php esc_html_e( 'Add Booster to your website - ', 'woocommerce-jetpack' ); ?><a target="_blank" href="<?php echo esc_url( wcj_build_commercial_url( 'account', array( 'path' => 'my-account/downloads/', 'campaign' => 'account', 'content' => 'dashboard_generate_key__account' ) ) ); ?>"><?php esc_html_e( 'Generate Key', 'woocommerce-jetpack' ); ?></a></p>
 							</div>
 						</div>
 						<div class="wcj-dash-sing-part">
@@ -235,7 +235,7 @@ if ( isset( $GLOBALS['wcj_getting_started_hub'] ) ) {
 					</div>
 					<!-- Promo Chips -->
 					<div id="wcj-promo-chips" class="wcj-promo-chips" role="navigation" aria-label="Primary Booster actions" data-gtm-container="promo_chips">
-						<a href="https://booster.io/buy-booster/" class="wcj-btn-chip" data-gtm="upgrade_click_elite" data-placement="dashboard_header" aria-label="Upgrade to Elite">
+						<a href="<?php echo esc_url( wcj_build_commercial_url( 'buy', array( 'campaign' => 'dashboard_header', 'content' => 'dashboard_header_upgrade_chip__buy' ) ) ); ?>" class="wcj-btn-chip" data-gtm="upgrade_click_elite" data-placement="dashboard_header" aria-label="Upgrade to Elite">
 							<?php esc_html_e( '⚡ Upgrade to Elite', 'woocommerce-jetpack' ); ?>
 						</a>
 						<a href="https://booster.io/changelog/" class="wcj-btn-chip" data-gtm="see_whats_new" data-placement="dashboard_header" aria-label="See What’s New">
@@ -297,7 +297,7 @@ if ( isset( $GLOBALS['wcj_getting_started_hub'] ) ) {
 					</ul>
 					<div class="wcj-upgrade-btn-part">
 						<div class="wcj-btn-main">
-							<a target="_blank" href="https://booster.io/free-vs-elite/" class="wcj-btn-sm wcj-btn-gray">
+							<a target="_blank" href="<?php echo esc_url( wcj_build_commercial_url( 'compare', array( 'campaign' => 'dashboard_header', 'content' => 'dashboard_header_compare_chip__compare' ) ) ); ?>" class="wcj-btn-sm wcj-btn-gray">
 								<?php esc_html_e( 'Free vs Elite (What’s included?)', 'woocommerce-jetpack' ); ?>
 							</a>
 						</div>

--- a/includes/admin/wcj-settings-dashboard.php
+++ b/includes/admin/wcj-settings-dashboard.php
@@ -116,7 +116,20 @@ if ( isset( $GLOBALS['wcj_getting_started_hub'] ) ) {
 							</div>
 							<div class="wcj-dash-sing-icon-dtl">
 								<h4><?php esc_html_e( 'Generate Site Key', 'woocommerce-jetpack' ); ?></h4>
-								<p><?php esc_html_e( 'Add Booster to your website - ', 'woocommerce-jetpack' ); ?><a target="_blank" href="<?php echo esc_url( wcj_build_commercial_url( 'account', array( 'path' => 'my-account/downloads/', 'campaign' => 'account', 'content' => 'dashboard_generate_key__account' ) ) ); ?>"><?php esc_html_e( 'Generate Key', 'woocommerce-jetpack' ); ?></a></p>
+								<p><?php esc_html_e( 'Add Booster to your website - ', 'woocommerce-jetpack' ); ?><a target="_blank" href="
+								<?php
+								echo esc_url(
+									wcj_build_commercial_url(
+										'account',
+										array(
+											'path'     => 'my-account/downloads/',
+											'campaign' => 'account',
+											'content'  => 'dashboard_generate_key__account',
+										)
+									)
+								);
+								?>
+								"><?php esc_html_e( 'Generate Key', 'woocommerce-jetpack' ); ?></a></p>
 							</div>
 						</div>
 						<div class="wcj-dash-sing-part">
@@ -235,7 +248,19 @@ if ( isset( $GLOBALS['wcj_getting_started_hub'] ) ) {
 					</div>
 					<!-- Promo Chips -->
 					<div id="wcj-promo-chips" class="wcj-promo-chips" role="navigation" aria-label="Primary Booster actions" data-gtm-container="promo_chips">
-						<a href="<?php echo esc_url( wcj_build_commercial_url( 'buy', array( 'campaign' => 'dashboard_header', 'content' => 'dashboard_header_upgrade_chip__buy' ) ) ); ?>" class="wcj-btn-chip" data-gtm="upgrade_click_elite" data-placement="dashboard_header" aria-label="Upgrade to Elite">
+						<a href="
+						<?php
+						echo esc_url(
+							wcj_build_commercial_url(
+								'buy',
+								array(
+									'campaign' => 'dashboard_header',
+									'content'  => 'dashboard_header_upgrade_chip__buy',
+								)
+							)
+						);
+						?>
+						" class="wcj-btn-chip" data-gtm="upgrade_click_elite" data-placement="dashboard_header" aria-label="Upgrade to Elite">
 							<?php esc_html_e( '⚡ Upgrade to Elite', 'woocommerce-jetpack' ); ?>
 						</a>
 						<a href="https://booster.io/changelog/" class="wcj-btn-chip" data-gtm="see_whats_new" data-placement="dashboard_header" aria-label="See What’s New">
@@ -297,7 +322,19 @@ if ( isset( $GLOBALS['wcj_getting_started_hub'] ) ) {
 					</ul>
 					<div class="wcj-upgrade-btn-part">
 						<div class="wcj-btn-main">
-							<a target="_blank" href="<?php echo esc_url( wcj_build_commercial_url( 'compare', array( 'campaign' => 'dashboard_header', 'content' => 'dashboard_header_compare_chip__compare' ) ) ); ?>" class="wcj-btn-sm wcj-btn-gray">
+							<a target="_blank" href="
+							<?php
+							echo esc_url(
+								wcj_build_commercial_url(
+									'compare',
+									array(
+										'campaign' => 'dashboard_header',
+										'content'  => 'dashboard_header_compare_chip__compare',
+									)
+								)
+							);
+							?>
+							" class="wcj-btn-sm wcj-btn-gray">
 								<?php esc_html_e( 'Free vs Elite (What’s included?)', 'woocommerce-jetpack' ); ?>
 							</a>
 						</div>

--- a/includes/admin/wcj-welcome-screen-content.php
+++ b/includes/admin/wcj-welcome-screen-content.php
@@ -24,7 +24,7 @@
 		<div class="wcj-welcome-content-main wcj-welcome-padding-top-0">
 			<div class="wcj-welcome-content-inner">
 				<div class="wcj-buy-puls-btn-main">
-					<a target="_blank" href="https://booster.io/buy-booster/" class="wcj-buy-puls-btn"> <?php esc_html_e( 'Upgrade Booster to unlock this feature.', 'woocommerce-jetpack' ); ?> </a>
+					<a target="_blank" href="<?php echo esc_url( wcj_build_commercial_url( 'buy', array( 'campaign' => 'dashboard_header', 'content' => 'welcome_screen_hero__buy' ) ) ); ?>" class="wcj-buy-puls-btn"> <?php esc_html_e( 'Upgrade Booster to unlock this feature.', 'woocommerce-jetpack' ); ?> </a>
 				</div>
 				<div class="wcj-welcome-content-inner wcj-buy-puls-content-row">
 					<div class="wcj-buy-puls-content-col-4">
@@ -129,7 +129,7 @@
 						</div>
 					</div>
 					<div class="wcj-buy-puls-btn-main">
-						<a target="_blank" href="https://booster.io/category/features/" class="wcj-buy-puls-btn"> <?php esc_html_e( 'See All Features', 'woocommerce-jetpack' ); ?> </a>
+						<a target="_blank" href="<?php echo esc_url( wcj_build_commercial_url( 'assist', array( 'path' => 'category/features/', 'campaign' => 'generic_upsell', 'content' => 'welcome_features_cta__assist' ) ) ); ?>" class="wcj-buy-puls-btn"> <?php esc_html_e( 'See All Features', 'woocommerce-jetpack' ); ?> </a>
 					</div>
 				</div>
 				<div id="subscribe-email" class="wcj-welcome-content-inner wcj-welcome-subscribe-email">
@@ -160,7 +160,7 @@
 					<h3> <?php esc_html_e( 'Contact Us', 'woocommerce-jetpack' ); ?> </h3>
 					<div class="wcj-support">
 						<p><?php esc_html_e( 'Booster Elite customers get access to Premium Support and we respond within 24 business hours.', 'woocommerce-jetpack' ); ?></p>
-						<a target="_blank" href="https://booster.io/my-account/booster-contact/"><?php esc_html_e( 'Booster Elite Premium Support', 'woocommerce-jetpack' ); ?></a>
+						<a target="_blank" href="<?php echo esc_url( wcj_build_commercial_url( 'account', array( 'path' => 'my-account/booster-contact/', 'campaign' => 'account', 'content' => 'welcome_premium_support__account' ) ) ); ?>"><?php esc_html_e( 'Booster Elite Premium Support', 'woocommerce-jetpack' ); ?></a>
 					</div>
 					<div class="wcj-support">
 						<p><?php esc_html_e( 'Free users post on WordPress Plugin Support forum here. We check these threads twice every week Mon and Frid to respond.', 'woocommerce-jetpack' ); ?></p>

--- a/includes/admin/wcj-welcome-screen-content.php
+++ b/includes/admin/wcj-welcome-screen-content.php
@@ -24,7 +24,19 @@
 		<div class="wcj-welcome-content-main wcj-welcome-padding-top-0">
 			<div class="wcj-welcome-content-inner">
 				<div class="wcj-buy-puls-btn-main">
-					<a target="_blank" href="<?php echo esc_url( wcj_build_commercial_url( 'buy', array( 'campaign' => 'dashboard_header', 'content' => 'welcome_screen_hero__buy' ) ) ); ?>" class="wcj-buy-puls-btn"> <?php esc_html_e( 'Upgrade Booster to unlock this feature.', 'woocommerce-jetpack' ); ?> </a>
+					<a target="_blank" href="
+					<?php
+					echo esc_url(
+						wcj_build_commercial_url(
+							'buy',
+							array(
+								'campaign' => 'dashboard_header',
+								'content'  => 'welcome_screen_hero__buy',
+							)
+						)
+					);
+					?>
+					" class="wcj-buy-puls-btn"> <?php esc_html_e( 'Upgrade Booster to unlock this feature.', 'woocommerce-jetpack' ); ?> </a>
 				</div>
 				<div class="wcj-welcome-content-inner wcj-buy-puls-content-row">
 					<div class="wcj-buy-puls-content-col-4">
@@ -129,7 +141,20 @@
 						</div>
 					</div>
 					<div class="wcj-buy-puls-btn-main">
-						<a target="_blank" href="<?php echo esc_url( wcj_build_commercial_url( 'assist', array( 'path' => 'category/features/', 'campaign' => 'generic_upsell', 'content' => 'welcome_features_cta__assist' ) ) ); ?>" class="wcj-buy-puls-btn"> <?php esc_html_e( 'See All Features', 'woocommerce-jetpack' ); ?> </a>
+						<a target="_blank" href="
+						<?php
+						echo esc_url(
+							wcj_build_commercial_url(
+								'assist',
+								array(
+									'path'     => 'category/features/',
+									'campaign' => 'generic_upsell',
+									'content'  => 'welcome_features_cta__assist',
+								)
+							)
+						);
+						?>
+						" class="wcj-buy-puls-btn"> <?php esc_html_e( 'See All Features', 'woocommerce-jetpack' ); ?> </a>
 					</div>
 				</div>
 				<div id="subscribe-email" class="wcj-welcome-content-inner wcj-welcome-subscribe-email">
@@ -160,7 +185,20 @@
 					<h3> <?php esc_html_e( 'Contact Us', 'woocommerce-jetpack' ); ?> </h3>
 					<div class="wcj-support">
 						<p><?php esc_html_e( 'Booster Elite customers get access to Premium Support and we respond within 24 business hours.', 'woocommerce-jetpack' ); ?></p>
-						<a target="_blank" href="<?php echo esc_url( wcj_build_commercial_url( 'account', array( 'path' => 'my-account/booster-contact/', 'campaign' => 'account', 'content' => 'welcome_premium_support__account' ) ) ); ?>"><?php esc_html_e( 'Booster Elite Premium Support', 'woocommerce-jetpack' ); ?></a>
+						<a target="_blank" href="
+						<?php
+						echo esc_url(
+							wcj_build_commercial_url(
+								'account',
+								array(
+									'path'     => 'my-account/booster-contact/',
+									'campaign' => 'account',
+									'content'  => 'welcome_premium_support__account',
+								)
+							)
+						);
+						?>
+						"><?php esc_html_e( 'Booster Elite Premium Support', 'woocommerce-jetpack' ); ?></a>
 					</div>
 					<div class="wcj-support">
 						<p><?php esc_html_e( 'Free users post on WordPress Plugin Support forum here. We check these threads twice every week Mon and Frid to respond.', 'woocommerce-jetpack' ); ?></p>

--- a/includes/cart-abandonment/wcj-cart-abandonment-orders-report.php
+++ b/includes/cart-abandonment/wcj-cart-abandonment-orders-report.php
@@ -15,7 +15,7 @@ $order_filter                    = filter_input( INPUT_GET, 'order_filter', FILT
 <div class="wcj-setting-jetpack-body cart_abandonment_main">	
 	<div class="wcj-col-12">
 	<?php echo wp_kses_post( $this->get_tool_header_html( 'cart_abandonment' ) ); ?>
-	<?php echo wp_kses_post( __( 'Want detailed reports, filtering, and to see recoverable vs. lost revenue? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank"> Booster Elite! </a>', 'woocommerce-jetpack' ) ); ?>
+	<?php echo wp_kses_post( wcj_replace_booster_url( __( 'Want detailed reports, filtering, and to see recoverable vs. lost revenue? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank"> Booster Elite! </a>', 'woocommerce-jetpack' ), wcj_build_commercial_url( 'compare', array( 'campaign' => 'module_feature_upsell', 'content' => 'cart_abandonment_reports__compare' ) ) ) ); ?>
 	</div>
 	<div class="wcj-col-12">
 		<?php

--- a/includes/cart-abandonment/wcj-cart-abandonment-orders-report.php
+++ b/includes/cart-abandonment/wcj-cart-abandonment-orders-report.php
@@ -15,7 +15,20 @@ $order_filter                    = filter_input( INPUT_GET, 'order_filter', FILT
 <div class="wcj-setting-jetpack-body cart_abandonment_main">	
 	<div class="wcj-col-12">
 	<?php echo wp_kses_post( $this->get_tool_header_html( 'cart_abandonment' ) ); ?>
-	<?php echo wp_kses_post( wcj_replace_booster_url( __( 'Want detailed reports, filtering, and to see recoverable vs. lost revenue? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank"> Booster Elite! </a>', 'woocommerce-jetpack' ), wcj_build_commercial_url( 'compare', array( 'campaign' => 'module_feature_upsell', 'content' => 'cart_abandonment_reports__compare' ) ) ) ); ?>
+	<?php
+	echo wp_kses_post(
+		wcj_replace_booster_url(
+			__( 'Want detailed reports, filtering, and to see recoverable vs. lost revenue? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank"> Booster Elite! </a>', 'woocommerce-jetpack' ),
+			wcj_build_commercial_url(
+				'compare',
+				array(
+					'campaign' => 'module_feature_upsell',
+					'content'  => 'cart_abandonment_reports__compare',
+				)
+			)
+		)
+	);
+	?>
 	</div>
 	<div class="wcj-col-12">
 		<?php

--- a/includes/class-wcj-price-by-user-role.php
+++ b/includes/class-wcj-price-by-user-role.php
@@ -301,7 +301,7 @@ if ( ! class_exists( 'WCJ_Price_By_User_Role' ) ) :
 			?><div class="error"><p>
 			<?php
 			echo '<div class="message">'
-				. wp_kses_post( __( 'Booster: Free plugin\'s version is limited to only one price by user role per products settings product enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of price by user role per product settings products.', 'woocommerce-jetpack' ) )
+				. wp_kses_post( wcj_replace_booster_url( __( 'Booster: Free plugin\'s version is limited to only one price by user role per products settings product enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of price by user role per product settings products.', 'woocommerce-jetpack' ), wcj_build_commercial_url( 'compare', array( 'campaign' => 'module_feature_upsell', 'content' => 'price_by_user_role_limit__compare' ) ) ) )
 				. '</div>';
 			?>
 		</p></div>

--- a/includes/class-wcj-price-by-user-role.php
+++ b/includes/class-wcj-price-by-user-role.php
@@ -301,7 +301,18 @@ if ( ! class_exists( 'WCJ_Price_By_User_Role' ) ) :
 			?><div class="error"><p>
 			<?php
 			echo '<div class="message">'
-				. wp_kses_post( wcj_replace_booster_url( __( 'Booster: Free plugin\'s version is limited to only one price by user role per products settings product enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of price by user role per product settings products.', 'woocommerce-jetpack' ), wcj_build_commercial_url( 'compare', array( 'campaign' => 'module_feature_upsell', 'content' => 'price_by_user_role_limit__compare' ) ) ) )
+				. wp_kses_post(
+					wcj_replace_booster_url(
+						__( 'Booster: Free plugin\'s version is limited to only one price by user role per products settings product enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of price by user role per product settings products.', 'woocommerce-jetpack' ),
+						wcj_build_commercial_url(
+							'compare',
+							array(
+								'campaign' => 'module_feature_upsell',
+								'content'  => 'price_by_user_role_limit__compare',
+							)
+						)
+					)
+				)
 				. '</div>';
 			?>
 		</p></div>
@@ -589,7 +600,6 @@ if ( ! class_exists( 'WCJ_Price_By_User_Role' ) ) :
 			}
 			return $price_hash;
 		}
-
 	}
 
 endif;

--- a/includes/class-wcj-product-addons.php
+++ b/includes/class-wcj-product-addons.php
@@ -336,7 +336,7 @@ if ( ! class_exists( 'WCJ_Product_Addons' ) ) :
 		 * @since   2.5.3
 		 */
 		public function get_the_notice() {
-			return __( 'Booster: Free plugin\'s version is limited to only three products with per product addons enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of products with per product addons.', 'woocommerce-jetpack' );
+			return wcj_replace_booster_url( __( 'Booster: Free plugin\'s version is limited to only three products with per product addons enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of products with per product addons.', 'woocommerce-jetpack' ), wcj_build_commercial_url( 'compare', array( 'campaign' => 'module_feature_upsell', 'content' => 'product_addons_limit__compare' ) ) );
 		}
 
 		/**

--- a/includes/class-wcj-product-addons.php
+++ b/includes/class-wcj-product-addons.php
@@ -336,7 +336,16 @@ if ( ! class_exists( 'WCJ_Product_Addons' ) ) :
 		 * @since   2.5.3
 		 */
 		public function get_the_notice() {
-			return wcj_replace_booster_url( __( 'Booster: Free plugin\'s version is limited to only three products with per product addons enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of products with per product addons.', 'woocommerce-jetpack' ), wcj_build_commercial_url( 'compare', array( 'campaign' => 'module_feature_upsell', 'content' => 'product_addons_limit__compare' ) ) );
+			return wcj_replace_booster_url(
+				__( 'Booster: Free plugin\'s version is limited to only three products with per product addons enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of products with per product addons.', 'woocommerce-jetpack' ),
+				wcj_build_commercial_url(
+					'compare',
+					array(
+						'campaign' => 'module_feature_upsell',
+						'content'  => 'product_addons_limit__compare',
+					)
+				)
+			);
 		}
 
 		/**
@@ -982,7 +991,6 @@ if ( ! class_exists( 'WCJ_Product_Addons' ) ) :
 				return wc_price( wcj_get_product_display_price( $_product, $this->maybe_convert_currency( $price, $_product ) ) );
 			}
 		}
-
 	}
 
 endif;

--- a/includes/class-wcj-product-bookings.php
+++ b/includes/class-wcj-product-bookings.php
@@ -545,7 +545,7 @@ if ( ! class_exists( 'WCJ_Product_Bookings' ) ) :
 		<div class="error"><p>
 			<?php
 			echo '<div class="message">'
-				. wp_kses_post( __( 'Booster: Free plugin\'s version is limited to only one bookings product enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of bookings products.', 'woocommerce-jetpack' ) )
+				. wp_kses_post( wcj_replace_booster_url( __( 'Booster: Free plugin\'s version is limited to only one bookings product enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of bookings products.', 'woocommerce-jetpack' ), wcj_build_commercial_url( 'compare', array( 'campaign' => 'module_feature_upsell', 'content' => 'product_bookings_limit__compare' ) ) ) )
 				. '</div>';
 			?>
 		</p></div>

--- a/includes/class-wcj-product-bookings.php
+++ b/includes/class-wcj-product-bookings.php
@@ -545,7 +545,18 @@ if ( ! class_exists( 'WCJ_Product_Bookings' ) ) :
 		<div class="error"><p>
 			<?php
 			echo '<div class="message">'
-				. wp_kses_post( wcj_replace_booster_url( __( 'Booster: Free plugin\'s version is limited to only one bookings product enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of bookings products.', 'woocommerce-jetpack' ), wcj_build_commercial_url( 'compare', array( 'campaign' => 'module_feature_upsell', 'content' => 'product_bookings_limit__compare' ) ) ) )
+				. wp_kses_post(
+					wcj_replace_booster_url(
+						__( 'Booster: Free plugin\'s version is limited to only one bookings product enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of bookings products.', 'woocommerce-jetpack' ),
+						wcj_build_commercial_url(
+							'compare',
+							array(
+								'campaign' => 'module_feature_upsell',
+								'content'  => 'product_bookings_limit__compare',
+							)
+						)
+					)
+				)
 				. '</div>';
 			?>
 		</p></div>
@@ -562,7 +573,6 @@ if ( ! class_exists( 'WCJ_Product_Bookings' ) ) :
 		public function is_bookings_product( $_product ) {
 			return ( 'yes' === get_post_meta( wcj_get_product_id_or_variation_parent_id( $_product ), '_wcj_product_bookings_enabled', true ) );
 		}
-
 	}
 
 endif;

--- a/includes/class-wcj-product-open-pricing.php
+++ b/includes/class-wcj-product-open-pricing.php
@@ -273,7 +273,7 @@ if ( ! class_exists( 'WCJ_Product_Open_Pricing' ) ) :
 			?><div class="error"><p>
 			<?php
 			echo '<div class="message">'
-				. wp_kses_post( 'Booster: Free plugin\'s version is limited to only one open pricing product enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of open pricing products.', 'woocommerce-jetpack' )
+				. wp_kses_post( wcj_replace_booster_url( __( 'Booster: Free plugin\'s version is limited to only one open pricing product enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of open pricing products.', 'woocommerce-jetpack' ), wcj_build_commercial_url( 'compare', array( 'campaign' => 'module_feature_upsell', 'content' => 'open_pricing_limit__compare' ) ) ) )
 				. '</div>';
 			?>
 		</p></div>

--- a/includes/class-wcj-product-open-pricing.php
+++ b/includes/class-wcj-product-open-pricing.php
@@ -273,7 +273,18 @@ if ( ! class_exists( 'WCJ_Product_Open_Pricing' ) ) :
 			?><div class="error"><p>
 			<?php
 			echo '<div class="message">'
-				. wp_kses_post( wcj_replace_booster_url( __( 'Booster: Free plugin\'s version is limited to only one open pricing product enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of open pricing products.', 'woocommerce-jetpack' ), wcj_build_commercial_url( 'compare', array( 'campaign' => 'module_feature_upsell', 'content' => 'open_pricing_limit__compare' ) ) ) )
+				. wp_kses_post(
+					wcj_replace_booster_url(
+						__( 'Booster: Free plugin\'s version is limited to only one open pricing product enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of open pricing products.', 'woocommerce-jetpack' ),
+						wcj_build_commercial_url(
+							'compare',
+							array(
+								'campaign' => 'module_feature_upsell',
+								'content'  => 'open_pricing_limit__compare',
+							)
+						)
+					)
+				)
 				. '</div>';
 			?>
 		</p></div>
@@ -596,7 +607,6 @@ if ( ! class_exists( 'WCJ_Product_Open_Pricing' ) ) :
 				$this->is_open_price_input_field_displayed = true;
 			}
 		}
-
 	}
 
 endif;

--- a/includes/class-wcj-product-price-by-formula.php
+++ b/includes/class-wcj-product-price-by-formula.php
@@ -471,7 +471,7 @@ if ( ! class_exists( 'WCJ_Product_Price_By_Formula' ) ) :
 			?><div class="error"><p>
 			<?php
 			echo '<div class="message">'
-				. wp_kses_post( 'Booster: Free plugin\'s version is limited to only one price by formula product enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of price by formula products.', 'woocommerce-jetpack' )
+				. wp_kses_post( wcj_replace_booster_url( __( 'Booster: Free plugin\'s version is limited to only one price by formula product enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of price by formula products.', 'woocommerce-jetpack' ), wcj_build_commercial_url( 'compare', array( 'campaign' => 'module_feature_upsell', 'content' => 'price_by_formula_limit__compare' ) ) ) )
 				. '</div>';
 			?>
 		</p></div>

--- a/includes/class-wcj-product-price-by-formula.php
+++ b/includes/class-wcj-product-price-by-formula.php
@@ -471,7 +471,18 @@ if ( ! class_exists( 'WCJ_Product_Price_By_Formula' ) ) :
 			?><div class="error"><p>
 			<?php
 			echo '<div class="message">'
-				. wp_kses_post( wcj_replace_booster_url( __( 'Booster: Free plugin\'s version is limited to only one price by formula product enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of price by formula products.', 'woocommerce-jetpack' ), wcj_build_commercial_url( 'compare', array( 'campaign' => 'module_feature_upsell', 'content' => 'price_by_formula_limit__compare' ) ) ) )
+				. wp_kses_post(
+					wcj_replace_booster_url(
+						__( 'Booster: Free plugin\'s version is limited to only one price by formula product enabled at a time. You will need to get <a href="https://booster.io/buy-booster/" target="_blank">Booster Elite</a> to add unlimited number of price by formula products.', 'woocommerce-jetpack' ),
+						wcj_build_commercial_url(
+							'compare',
+							array(
+								'campaign' => 'module_feature_upsell',
+								'content'  => 'price_by_formula_limit__compare',
+							)
+						)
+					)
+				)
 				. '</div>';
 			?>
 		</p></div>
@@ -512,7 +523,6 @@ if ( ! class_exists( 'WCJ_Product_Price_By_Formula' ) ) :
 				echo wp_kses_post( wc_price( $the_price ) );
 			}
 		}
-
 	}
 
 endif;

--- a/includes/class-wcj-product-variation-swatches.php
+++ b/includes/class-wcj-product-variation-swatches.php
@@ -251,7 +251,7 @@ if ( ! class_exists( 'WCJ_Product_Variation_Swatches' ) ) :
 					<?php echo wp_kses_post( "Determines how this attribute's values are displayed like Color Box or As Image", 'woocommerce-jetpack' ); ?>
 				</p>
 				<p class="description">
-					<?php echo wp_kses_post( 'Want to enable swatches for all your attributes, use button/label swatches, or automatically convert all dropdowns? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank"> Booster Elite </a> for advanced swatch control!', 'woocommerce-jetpack' ); ?>
+					<?php echo wp_kses_post( wcj_replace_booster_url( __( 'Want to enable swatches for all your attributes, use button/label swatches, or automatically convert all dropdowns? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank"> Booster Elite </a> for advanced swatch control!', 'woocommerce-jetpack' ), wcj_build_commercial_url( 'compare', array( 'campaign' => 'module_feature_upsell', 'content' => 'variation_swatches_notice__compare' ) ) ) ); ?>
 				</p>
 			</div>
 				<?php

--- a/includes/class-wcj-product-variation-swatches.php
+++ b/includes/class-wcj-product-variation-swatches.php
@@ -251,7 +251,20 @@ if ( ! class_exists( 'WCJ_Product_Variation_Swatches' ) ) :
 					<?php echo wp_kses_post( "Determines how this attribute's values are displayed like Color Box or As Image", 'woocommerce-jetpack' ); ?>
 				</p>
 				<p class="description">
-					<?php echo wp_kses_post( wcj_replace_booster_url( __( 'Want to enable swatches for all your attributes, use button/label swatches, or automatically convert all dropdowns? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank"> Booster Elite </a> for advanced swatch control!', 'woocommerce-jetpack' ), wcj_build_commercial_url( 'compare', array( 'campaign' => 'module_feature_upsell', 'content' => 'variation_swatches_notice__compare' ) ) ) ); ?>
+					<?php
+					echo wp_kses_post(
+						wcj_replace_booster_url(
+							__( 'Want to enable swatches for all your attributes, use button/label swatches, or automatically convert all dropdowns? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank"> Booster Elite </a> for advanced swatch control!', 'woocommerce-jetpack' ),
+							wcj_build_commercial_url(
+								'compare',
+								array(
+									'campaign' => 'module_feature_upsell',
+									'content'  => 'variation_swatches_notice__compare',
+								)
+							)
+						)
+					);
+					?>
 				</p>
 			</div>
 				<?php

--- a/includes/class-wcj-upgrade-blocks.php
+++ b/includes/class-wcj-upgrade-blocks.php
@@ -21,7 +21,7 @@ if ( ! function_exists( 'wcj_get_upgrade_blocks_config' ) ) {
 	 * Returns an array of upgrade block configurations for modules that have
 	 * Lite versions in the free plugin and enhanced features in Elite.
 	 *
-	 * @version 7.10.0
+	 * @version 7.11.4
 	 * @since   7.9.0
 	 * @return  array Upgrade block configurations keyed by module_id.
 	 */
@@ -146,6 +146,31 @@ if ( ! function_exists( 'wcj_get_upgrade_blocks_config' ) ) {
 				'upgrade_url'    => 'https://booster.io/buy-booster/',
 			),
 		);
+
+		foreach ( $config as $module_id => &$module_config ) {
+			if ( ! empty( $module_config['comparison_url'] ) ) {
+				$module_config['comparison_url'] = wcj_build_commercial_url(
+					'assist',
+					array(
+						'campaign' => 'module_upgrade_block',
+						'content'  => sanitize_key( $module_id ) . '__assist',
+						'url'      => $module_config['comparison_url'],
+					)
+				);
+			}
+
+			if ( ! empty( $module_config['upgrade_url'] ) ) {
+				$module_config['upgrade_url'] = wcj_build_commercial_url(
+					'buy',
+					array(
+						'campaign' => 'module_upgrade_block',
+						'content'  => sanitize_key( $module_id ) . '__buy',
+						'url'      => $module_config['upgrade_url'],
+					)
+				);
+			}
+		}
+		unset( $module_config );
 
 		/**
 		 * Filter upgrade block configurations.

--- a/includes/classes/class-wcj-module.php
+++ b/includes/classes/class-wcj-module.php
@@ -476,7 +476,15 @@ if ( ! class_exists( 'WCJ_Module' ) ) :
 				/* translators: %1$s,%2$s: translators Added */
 				wp_kses_post( __( 'Booster: Free plugin\'s version is limited to only one "%1$s" product with settings on per product basis enabled at a time. You will need to get <a href="%2$s" target="_blank">Booster Elite</a> to add unlimited number of "%1$s" products.', 'woocommerce-jetpack' ) ),
 				wp_kses_post( $this->short_desc ),
-				'https://booster.io/buy-booster/'
+				esc_url(
+					wcj_build_commercial_url(
+						'compare',
+						array(
+							'campaign' => 'module_feature_upsell',
+							'content'  => sanitize_key( $this->id ) . '_limit__compare',
+						)
+					)
+				)
 			) .
 			'</div></p></div>';
 		}

--- a/includes/classes/class-wcj-module.php
+++ b/includes/classes/class-wcj-module.php
@@ -188,11 +188,9 @@ if ( ! class_exists( 'WCJ_Module' ) ) :
 			if ( 'no' === wcj_get_option( 'wcj_load_modules_on_init', 'no' ) ) {
 				add_action( 'init', array( $this, 'add_settings' ) );
 				add_action( 'init', array( $this, 'reset_settings' ), PHP_INT_MAX );
-			} else {
-				if ( 'init' === current_filter() || 'plugins_loaded' === current_filter() ) {
+			} elseif ( 'init' === current_filter() || 'plugins_loaded' === current_filter() ) {
 					$this->add_settings();
 					$this->reset_settings();
-				}
 			}
 
 			// Handle WPML hooks.
@@ -836,7 +834,6 @@ if ( ! class_exists( 'WCJ_Module' ) ) :
 					$priority
 				);
 			}
-
 		}
 
 		/**

--- a/includes/core/class-wcj-admin.php
+++ b/includes/core/class-wcj-admin.php
@@ -338,14 +338,32 @@ if ( ! class_exists( 'WCJ_Admin' ) ) :
 				sprintf(
 				/* translators: %s: search term */
 					__( 'Visit <a target="_blank" href="%s">your account page</a> on booster.io to download the latest Booster Elite version.', 'woocommerce-jetpack' ),
-					'https://booster.io/my-account/?utm_source=plus_update'
+					esc_url(
+						wcj_build_commercial_url(
+							'renewal',
+							array(
+								'path'     => 'my-account/',
+								'campaign' => 'renewal',
+								'content'  => 'deprecated_plus_update_notice__account',
+							)
+						)
+					)
 				) . ' ' .
 				sprintf(
 				/* translators: %s: search term */
 					__( 'Click <a target="_blank" href="%s">here</a> for more info.', 'woocommerce-jetpack' ),
-					'https://booster.io/booster-elite-for-woocommerce-update/'
+					esc_url(
+						wcj_build_commercial_url(
+							'renewal',
+							array(
+								'path'     => 'booster-elite-for-woocommerce-update/',
+								'campaign' => 'renewal',
+								'content'  => 'deprecated_plus_update_notice__update_info',
+							)
+						)
+					)
 				);
-				echo '<div class="' . esc_html( $class ) . '"><p>' . esc_html( $message ) . '</p></div>';
+				echo '<div class="' . esc_attr( $class ) . '"><p>' . wp_kses_post( $message ) . '</p></div>';
 			}
 		}
 
@@ -477,9 +495,9 @@ if ( ! class_exists( 'WCJ_Admin' ) ) :
 				'<a href="' . esc_url( 'https://booster.io/' ) . '">' . __( 'Docs', 'woocommerce-jetpack' ) . '</a>',
 			);
 			if ( 'woocommerce-jetpack.php' === basename( WCJ_FREE_PLUGIN_FILE ) ) {
-				$custom_links[] = '<a target="_blank" href="' . esc_url( 'https://booster.io/buy-booster/' ) . '">' . __( 'Unlock all', 'woocommerce-jetpack' ) . '</a>';
+				$custom_links[] = '<a target="_blank" href="' . esc_url( wcj_build_commercial_url( 'buy', array( 'campaign' => 'dashboard_header', 'content' => 'plugin_action_unlock_all__buy' ) ) ) . '">' . __( 'Unlock all', 'woocommerce-jetpack' ) . '</a>';
 			} else {
-				$custom_links[] = '<a target="_blank" href="' . esc_url( 'https://booster.io/my-account/booster-contact/' ) . '">' . __( 'Support', 'woocommerce-jetpack' ) . '</a>';
+				$custom_links[] = '<a target="_blank" href="' . esc_url( wcj_build_commercial_url( 'account', array( 'path' => 'my-account/booster-contact/', 'campaign' => 'account', 'content' => 'plugin_action_support__account' ) ) ) . '">' . __( 'Support', 'woocommerce-jetpack' ) . '</a>';
 			}
 			return array_merge( $custom_links, $links );
 		}

--- a/includes/core/class-wcj-admin.php
+++ b/includes/core/class-wcj-admin.php
@@ -495,9 +495,26 @@ if ( ! class_exists( 'WCJ_Admin' ) ) :
 				'<a href="' . esc_url( 'https://booster.io/' ) . '">' . __( 'Docs', 'woocommerce-jetpack' ) . '</a>',
 			);
 			if ( 'woocommerce-jetpack.php' === basename( WCJ_FREE_PLUGIN_FILE ) ) {
-				$custom_links[] = '<a target="_blank" href="' . esc_url( wcj_build_commercial_url( 'buy', array( 'campaign' => 'dashboard_header', 'content' => 'plugin_action_unlock_all__buy' ) ) ) . '">' . __( 'Unlock all', 'woocommerce-jetpack' ) . '</a>';
+				$custom_links[] = '<a target="_blank" href="' . esc_url(
+					wcj_build_commercial_url(
+						'buy',
+						array(
+							'campaign' => 'dashboard_header',
+							'content'  => 'plugin_action_unlock_all__buy',
+						)
+					)
+				) . '">' . __( 'Unlock all', 'woocommerce-jetpack' ) . '</a>';
 			} else {
-				$custom_links[] = '<a target="_blank" href="' . esc_url( wcj_build_commercial_url( 'account', array( 'path' => 'my-account/booster-contact/', 'campaign' => 'account', 'content' => 'plugin_action_support__account' ) ) ) . '">' . __( 'Support', 'woocommerce-jetpack' ) . '</a>';
+				$custom_links[] = '<a target="_blank" href="' . esc_url(
+					wcj_build_commercial_url(
+						'account',
+						array(
+							'path'     => 'my-account/booster-contact/',
+							'campaign' => 'account',
+							'content'  => 'plugin_action_support__account',
+						)
+					)
+				) . '">' . __( 'Support', 'woocommerce-jetpack' ) . '</a>';
 			}
 			return array_merge( $custom_links, $links );
 		}

--- a/includes/functions/wcj-functions-admin.php
+++ b/includes/functions/wcj-functions-admin.php
@@ -339,11 +339,131 @@ if ( ! function_exists( 'wcj_get_5_rocket_image' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wcj_build_commercial_url' ) ) {
+	/**
+	 * Build a tagged Booster commercial/account URL for in-plugin CTAs.
+	 *
+	 * Internal helper used under existing public CTA mechanisms so routing and
+	 * UTM tagging stay consistent without a broad API migration.
+	 *
+	 * @version 7.11.4
+	 * @since   7.11.4
+	 * @param   string $intent  compare|buy|assist|account|renewal.
+	 * @param   array  $context Optional routing and tagging context.
+	 * @return  string
+	 */
+	function wcj_build_commercial_url( $intent, $context = array() ) {
+		$context = wp_parse_args(
+			$context,
+			array(
+				'url'       => '',
+				'path'      => '',
+				'source'    => 'booster',
+				'medium'    => 'inplugin',
+				'campaign'  => '',
+				'content'   => '',
+				'surface'   => '',
+				'module_id' => '',
+				'cta_id'    => '',
+				'fragment'  => '',
+				'query_args' => array(),
+			)
+		);
+
+		$intent           = sanitize_key( $intent );
+		$base_url         = 'https://booster.io/';
+		$default_campaign = 'generic_upsell';
+		$default_suffix   = 'assist';
+
+		switch ( $intent ) {
+			case 'compare':
+				$base_url         = 'https://booster.io/free-vs-elite/';
+				$default_campaign = 'generic_upsell';
+				$default_suffix   = 'compare';
+				break;
+			case 'buy':
+				$base_url         = 'https://booster.io/buy-booster/';
+				$default_campaign = 'generic_upsell';
+				$default_suffix   = 'buy';
+				break;
+			case 'account':
+				$base_url         = 'https://booster.io/my-account/';
+				$default_campaign = 'account';
+				$default_suffix   = 'account';
+				break;
+			case 'renewal':
+				$base_url         = 'https://booster.io/my-account/';
+				$default_campaign = 'renewal';
+				$default_suffix   = 'account';
+				break;
+		}
+
+		if ( ! empty( $context['url'] ) ) {
+			$base_url = (string) $context['url'];
+		} elseif ( ! empty( $context['path'] ) ) {
+			$base_url = 'https://booster.io/' . ltrim( (string) $context['path'], '/' );
+			if ( false === strpos( $base_url, '?' ) && false === strpos( $base_url, '#' ) && '/' !== substr( $base_url, -1 ) ) {
+				$base_url .= '/';
+			}
+		}
+
+		$campaign = ( ! empty( $context['campaign'] ) ? sanitize_key( $context['campaign'] ) : $default_campaign );
+
+		if ( ! empty( $context['content'] ) ) {
+			$content = sanitize_key( $context['content'] );
+		} else {
+			$content_parts = array_filter(
+				array(
+					sanitize_key( $context['surface'] ),
+					sanitize_key( $context['module_id'] ),
+					sanitize_key( $context['cta_id'] ),
+				)
+			);
+			$content       = ( empty( $content_parts ) ? 'admin' : implode( '_', $content_parts ) ) . '__' . $default_suffix;
+		}
+
+		$query_args = array(
+			'utm_source'   => sanitize_key( $context['source'] ),
+			'utm_medium'   => sanitize_key( $context['medium'] ),
+			'utm_campaign' => $campaign,
+			'utm_content'  => $content,
+		);
+
+		if ( ! empty( $context['query_args'] ) && is_array( $context['query_args'] ) ) {
+			$query_args = array_merge( $query_args, $context['query_args'] );
+		}
+
+		$url = add_query_arg( array_filter( $query_args, 'strlen' ), $base_url );
+
+		if ( ! empty( $context['fragment'] ) ) {
+			$url .= '#' . ltrim( (string) $context['fragment'], '#' );
+		}
+
+		return $url;
+	}
+}
+
+if ( ! function_exists( 'wcj_replace_booster_url' ) ) {
+	/**
+	 * Replace a hardcoded Booster URL inside translated HTML.
+	 *
+	 * @version 7.11.4
+	 * @since   7.11.4
+	 * @param   string $text         HTML/text that contains the original URL.
+	 * @param   string $new_url      Replacement URL.
+	 * @param   string $original_url URL currently embedded in the string.
+	 * @return  string
+	 */
+	function wcj_replace_booster_url( $text, $new_url, $original_url = 'https://booster.io/buy-booster/' ) {
+		return str_replace( $original_url, esc_url( $new_url ), $text );
+	}
+}
+
 if ( ! function_exists( 'wcj_get_plus_message' ) ) {
 	/**
 	 * Wcj_get_plus_message.
 	 *
-	 * @version 7.2.9
+	 * @version 7.11.4
 	 * @param   string | array $value defines the value.
 	 * @param   string         $message_type defines the message_type.
 	 * @param   array          $args defines the args.
@@ -353,25 +473,76 @@ if ( ! function_exists( 'wcj_get_plus_message' ) ) {
 		switch ( $message_type ) {
 
 			case 'global':
+				$compare_text_url = esc_url(
+					wcj_build_commercial_url(
+						'compare',
+						array(
+							'campaign' => 'generic_upsell',
+							'content'  => 'plus_message_global__compare_text',
+						)
+					)
+				);
+				$buy_url          = esc_url(
+					wcj_build_commercial_url(
+						'buy',
+						array(
+							'campaign' => 'generic_upsell',
+							'content'  => 'plus_message_global__buy_button',
+						)
+					)
+				);
+				$site_url         = esc_url(
+					wcj_build_commercial_url(
+						'assist',
+						array(
+							'campaign' => 'generic_upsell',
+							'content'  => 'plus_message_global__assist',
+							'url'      => 'https://booster.io/',
+						)
+					)
+				);
 				return '<div class="notice notice-warning">' .
 					'<p><strong>' . __( 'Upgrade Booster to unlock this feature', 'woocommerce-jetpack' ) . '</strong></p>' .
 					'<p><span>' . sprintf(
 						/* translators: %s: translation added */
 						__( 'Some settings fields are locked and you will need %s to modify all locked fields.', 'woocommerce-jetpack' ),
-						'<a href="https://booster.io/free-vs-elite/?utm_source=inplugin&utm_medium=upsell&utm_campaign=upgrade_prompt&utm_content=central_function_prompt" target="_blank">Booster for WooCommerce </a>'
+						'<a href="' . $compare_text_url . '" target="_blank">Booster for WooCommerce </a>'
 					) . '</span></p>' .
 					'<p>' .
-					'<a href="https://booster.io/free-vs-elite/?utm_source=inplugin&utm_medium=upsell&utm_campaign=upgrade_prompt&utm_content=central_function_prompt" target="_blank" class="button button-primary">' . __( 'Buy now', 'woocommerce-jetpack' ) . '</a> <a href="https://booster.io" target="_blank" class="button">' . __( 'Visit Booster Site', 'woocommerce-jetpack' ) . '</a>' .
+					'<a href="' . $buy_url . '" target="_blank" class="button button-primary">' . __( 'Buy now', 'woocommerce-jetpack' ) . '</a> <a href="' . $site_url . '" target="_blank" class="button">' . __( 'Visit Booster Site', 'woocommerce-jetpack' ) . '</a>' .
 					'</p>' .
 					'</div>';
 
 			case 'desc':
 				/* translators: %s: translation added */
-				return sprintf( __( 'Upgrade <a href="%s" target="_blank">Booster</a> to change value.', 'woocommerce-jetpack' ), 'https://booster.io/free-vs-elite/?utm_source=inplugin&utm_medium=upsell&utm_campaign=upgrade_prompt&utm_content=central_function_prompt' );
+				return sprintf(
+					__( 'Upgrade <a href="%s" target="_blank">Booster</a> to change value.', 'woocommerce-jetpack' ),
+					esc_url(
+						wcj_build_commercial_url(
+							'compare',
+							array(
+								'campaign' => 'generic_upsell',
+								'content'  => 'plus_message_desc__compare',
+							)
+						)
+					)
+				);
 
 			case 'desc_advanced':
 				/* translators: %s: translation added */
-				return sprintf( __( 'Upgrade <a href="%1$s" target="_blank">Booster to unlock this feature</a> to enable "%2$s" option.', 'woocommerce-jetpack' ), 'https://booster.io/free-vs-elite/?utm_source=inplugin&utm_medium=upsell&utm_campaign=upgrade_prompt&utm_content=central_function_prompt', $args['option'] );
+				return sprintf(
+					__( 'Upgrade <a href="%1$s" target="_blank">Booster to unlock this feature</a> to enable "%2$s" option.', 'woocommerce-jetpack' ),
+					esc_url(
+						wcj_build_commercial_url(
+							'compare',
+							array(
+								'campaign' => 'generic_upsell',
+								'content'  => 'plus_message_desc_advanced__compare',
+							)
+						)
+					),
+					$args['option']
+				);
 
 			case 'desc_advanced_no_link':
 				/* translators: %s: translation added */
@@ -379,11 +550,33 @@ if ( ! function_exists( 'wcj_get_plus_message' ) ) {
 
 			case 'desc_below':
 				/* translators: %s: translation added */
-				return sprintf( __( 'Upgrade  <a href="%s" target="_blank">Booster</a> to change values below.', 'woocommerce-jetpack' ), 'https://booster.io/free-vs-elite/?utm_source=inplugin&utm_medium=upsell&utm_campaign=upgrade_prompt&utm_content=central_function_prompt' );
+				return sprintf(
+					__( 'Upgrade  <a href="%s" target="_blank">Booster</a> to change values below.', 'woocommerce-jetpack' ),
+					esc_url(
+						wcj_build_commercial_url(
+							'compare',
+							array(
+								'campaign' => 'generic_upsell',
+								'content'  => 'plus_message_desc_below__compare',
+							)
+						)
+					)
+				);
 
 			case 'desc_above':
 				/* translators: %s: translation added */
-				return sprintf( __( 'Upgrade  <a href="%s" target="_blank">Booster </a> to change values above.', 'woocommerce-jetpack' ), 'https://booster.io/free-vs-elite/?utm_source=inplugin&utm_medium=upsell&utm_campaign=upgrade_prompt&utm_content=central_function_prompt' );
+				return sprintf(
+					__( 'Upgrade  <a href="%s" target="_blank">Booster </a> to change values above.', 'woocommerce-jetpack' ),
+					esc_url(
+						wcj_build_commercial_url(
+							'compare',
+							array(
+								'campaign' => 'generic_upsell',
+								'content'  => 'plus_message_desc_above__compare',
+							)
+						)
+					)
+				);
 
 			case 'desc_no_link':
 				return __( 'Upgrade Booster to change value.', 'woocommerce-jetpack' );

--- a/includes/functions/wcj-functions-admin.php
+++ b/includes/functions/wcj-functions-admin.php
@@ -144,7 +144,7 @@ if ( ! function_exists( 'wcj_admin_notices_version_updated' ) ) {
 			$class = 'notice notice-success is-dismissible';
 			/* translators: %s: translation added */
 			$message = sprintf( __( '<strong>Booster for WooCommerce</strong> plugin was successfully updated to version <strong>%s</strong>.', 'woocommerce-jetpack' ), w_c_j()->version );
-			echo sprintf( '<div class="%1$s"><p>%2$s</p></div>', wp_kses_post( $class ), wp_kses_post( $message ) );
+			printf( '<div class="%1$s"><p>%2$s</p></div>', wp_kses_post( $class ), wp_kses_post( $message ) );
 		}
 	}
 }
@@ -285,11 +285,9 @@ if ( ! function_exists( 'wcj_maybe_convert_and_update_option_value' ) ) {
 					$value = implode( ',', $value );
 					update_option( $option['id'], $value );
 				}
-			} else {
-				if ( is_string( $value ) ) {
+			} elseif ( is_string( $value ) ) {
 					$value = wcj_convert_string_to_array( $value );
 					update_option( $option['id'], $value );
-				}
 			}
 		}
 	}
@@ -356,16 +354,16 @@ if ( ! function_exists( 'wcj_build_commercial_url' ) ) {
 		$context = wp_parse_args(
 			$context,
 			array(
-				'url'       => '',
-				'path'      => '',
-				'source'    => 'booster',
-				'medium'    => 'inplugin',
-				'campaign'  => '',
-				'content'   => '',
-				'surface'   => '',
-				'module_id' => '',
-				'cta_id'    => '',
-				'fragment'  => '',
+				'url'        => '',
+				'path'       => '',
+				'source'     => 'booster',
+				'medium'     => 'inplugin',
+				'campaign'   => '',
+				'content'    => '',
+				'surface'    => '',
+				'module_id'  => '',
+				'cta_id'     => '',
+				'fragment'   => '',
 				'query_args' => array(),
 			)
 		);
@@ -514,8 +512,8 @@ if ( ! function_exists( 'wcj_get_plus_message' ) ) {
 					'</div>';
 
 			case 'desc':
-				/* translators: %s: translation added */
 				return sprintf(
+					/* translators: %s: translation added */
 					__( 'Upgrade <a href="%s" target="_blank">Booster</a> to change value.', 'woocommerce-jetpack' ),
 					esc_url(
 						wcj_build_commercial_url(
@@ -529,8 +527,8 @@ if ( ! function_exists( 'wcj_get_plus_message' ) ) {
 				);
 
 			case 'desc_advanced':
-				/* translators: %s: translation added */
 				return sprintf(
+					/* translators: %s: translation added */
 					__( 'Upgrade <a href="%1$s" target="_blank">Booster to unlock this feature</a> to enable "%2$s" option.', 'woocommerce-jetpack' ),
 					esc_url(
 						wcj_build_commercial_url(
@@ -549,8 +547,8 @@ if ( ! function_exists( 'wcj_get_plus_message' ) ) {
 				return sprintf( __( 'Upgrade Booster to to enable "%s" option.', 'woocommerce-jetpack' ), $args['option'] );
 
 			case 'desc_below':
-				/* translators: %s: translation added */
 				return sprintf(
+					/* translators: %s: translation added */
 					__( 'Upgrade  <a href="%s" target="_blank">Booster</a> to change values below.', 'woocommerce-jetpack' ),
 					esc_url(
 						wcj_build_commercial_url(
@@ -564,8 +562,8 @@ if ( ! function_exists( 'wcj_get_plus_message' ) ) {
 				);
 
 			case 'desc_above':
-				/* translators: %s: translation added */
 				return sprintf(
+					/* translators: %s: translation added */
 					__( 'Upgrade  <a href="%s" target="_blank">Booster </a> to change values above.', 'woocommerce-jetpack' ),
 					esc_url(
 						wcj_build_commercial_url(

--- a/includes/settings/wcj-settings-cart-abandonment.php
+++ b/includes/settings/wcj-settings-cart-abandonment.php
@@ -24,6 +24,16 @@ if ( function_exists( 'wcj_render_upgrade_block' ) && wcj_has_upgrade_block( 'ca
 	wcj_render_upgrade_block( 'cart_abandonment' );
 }
 
+$wcj_cart_abandonment_compare_url = function ( $content ) {
+	return wcj_build_commercial_url(
+		'compare',
+		array(
+			'campaign' => 'locked_setting',
+			'content'  => $content,
+		)
+	);
+};
+
 $settings = array(
 	array(
 		'id'   => 'wcj_cart_abandonment_options',
@@ -52,7 +62,7 @@ $settings = array(
 		'class'             => 'chosen_select',
 		'options'           => $user_roles,
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Need to restrict access to abandoned cart settings and data based on user roles? <br> Upgrade <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to set user roles.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Need to restrict access to abandoned cart settings and data based on user roles? <br> Upgrade <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to set user roles.', 'woocommerce-jetpack' ), $wcj_cart_abandonment_compare_url( 'cart_abandonment_roles__compare' ) ),
 		'help_text'         => __( 'Select user roles that should be excluded from abandoned cart tracking. For example, exclude administrators or shop managers to avoid tracking internal test orders.', 'woocommerce-jetpack' ),
 	),
 	array(
@@ -114,7 +124,7 @@ $settings = array(
 		'id'                => 'wcj_ca_email_template_total_number',
 		'default'           => 1,
 		'type'              => 'custom_number',
-		'desc'              => __( 'Need to send a sequence of emails at custom intervals? Want to customize sender details or use advanced email templates? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank"> Booster </a> for full automation control!', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Need to send a sequence of emails at custom intervals? Want to customize sender details or use advanced email templates? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank"> Booster </a> for full automation control!', 'woocommerce-jetpack' ), $wcj_cart_abandonment_compare_url( 'cart_abandonment_automation__compare' ) ),
 		'custom_attributes' => apply_filters( 'booster_message', '', 'readonly' ),
 		'help_text'         => __( 'Set the number of reminder emails to send for each abandoned cart. Most stores use 2-3 emails: one after 1 hour, another after 24 hours, and optionally a final reminder after 3 days.', 'woocommerce-jetpack' ),
 		'friendly_label'    => __( 'Number of Reminder Emails', 'woocommerce-jetpack' ),
@@ -186,7 +196,7 @@ for ( $i = 1; $i <= $total_number; $i++ ) {
 			),
 			array(
 				'title'             => __( 'Discount Type', 'woocommerce-jetpack' ),
-				'desc'              => __( 'Want to supercharge recovery by offering a discount coupon in your reminder emails? This powerful feature is available in <a href="https://booster.io/buy-booster/" target="_blank"> Booster Elite! </a> ', 'woocommerce-jetpack' ),
+				'desc'              => wcj_replace_booster_url( __( 'Want to supercharge recovery by offering a discount coupon in your reminder emails? This powerful feature is available in <a href="https://booster.io/buy-booster/" target="_blank"> Booster Elite! </a> ', 'woocommerce-jetpack' ), $wcj_cart_abandonment_compare_url( 'cart_abandonment_coupons__compare' ) ),
 				'id'                => 'wcj_ca_email_discount_type_' . $i,
 				'default'           => 'No Discount',
 				'type'              => 'select',

--- a/includes/settings/wcj-settings-preorders.php
+++ b/includes/settings/wcj-settings-preorders.php
@@ -19,6 +19,15 @@ if ( function_exists( 'wcj_render_upgrade_block' ) && wcj_has_upgrade_block( 'pr
 $user_roles   = wcj_get_user_roles_options();
 $product_cats = wcj_get_terms( 'product_cat' );
 $products     = wcj_get_products();
+$wcj_preorders_compare_url = function ( $content ) {
+	return wcj_build_commercial_url(
+		'compare',
+		array(
+			'campaign' => 'locked_setting',
+			'content'  => $content,
+		)
+	);
+};
 
 $settings = array(
 	array(
@@ -39,7 +48,7 @@ $settings = array(
 	),
 	array(
 		'title'             => __( 'Prevent Mixed Cart', 'woocommerce-jetpack' ),
-		'desc'              => __( 'Want to ensure pre-order items are purchased separately from regular stock for easier management? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock this feature.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Want to ensure pre-order items are purchased separately from regular stock for easier management? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock this feature.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_separate_cart__compare' ) ),
 		'id'                => 'wcj_preorders_prevent_mixed_cart',
 		'default'           => 'no',
 		'type'              => 'checkbox',
@@ -51,7 +60,7 @@ $settings = array(
 		'default'           => 'm/d/Y',
 		'type'              => 'text',
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Choose the input format for release dates. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to customize release date formats.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Choose the input format for release dates. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to customize release date formats.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_release_date_format__compare' ) ),
 	),
 	array(
 		'title'             => __( 'Pre-order Access', 'woocommerce-jetpack' ),
@@ -64,7 +73,7 @@ $settings = array(
 			'roles'      => __( 'Specific User Roles', 'woocommerce-jetpack' ),
 		),
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Control who can place pre-orders (all users, logged-in users, or specific roles). Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock role-based access.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Control who can place pre-orders (all users, logged-in users, or specific roles). Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock role-based access.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_role_access__compare' ) ),
 	),
 	array(
 		'title'             => __( 'Allowed User Roles', 'woocommerce-jetpack' ),
@@ -73,7 +82,7 @@ $settings = array(
 		'type'              => 'multiselect',
 		'options'           => $user_roles,
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Select specific user roles allowed to place pre-orders. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock role-based restrictions.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Select specific user roles allowed to place pre-orders. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock role-based restrictions.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_role_selection__compare' ) ),
 	),
 	array(
 		'id'   => 'wcj_preorders_general_tab',
@@ -89,14 +98,14 @@ $settings = array(
 		'default'           => array(),
 		'type'              => 'multiselect',
 		'options'           => $products,
-		'desc'              => __( 'Select up to 3 products to enable pre-orders. Want to enable pre-orders for unlimited products? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock this feature.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Select up to 3 products to enable pre-orders. Want to enable pre-orders for unlimited products? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock this feature.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_unlimited_products__compare' ) ),
 		'custom_attributes' => array(
 			'data-max-selected' => 3,
 		),
 	),
 	array(
 		'title'             => __( 'Auto-enable Pre-orders', 'woocommerce-jetpack' ),
-		'desc'              => __( 'Want to enable pre-orders automatically for all out-of-stock items? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock this feature.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Want to enable pre-orders automatically for all out-of-stock items? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock this feature.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_auto_enable__compare' ) ),
 		'id'                => 'wcj_preorders_auto_enable_outofstock',
 		'default'           => 'no',
 		'type'              => 'checkbox',
@@ -104,7 +113,7 @@ $settings = array(
 	),
 	array(
 		'title'             => __( 'Product Categories - Include', 'woocommerce-jetpack' ),
-		'desc'              => __( 'Auto-enable pre-orders only for products in these categories. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock category-based pre-orders.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Auto-enable pre-orders only for products in these categories. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock category-based pre-orders.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_category_include__compare' ) ),
 		'id'                => 'wcj_preorders_auto_enable_categories_include',
 		'default'           => array(),
 		'type'              => 'multiselect',
@@ -113,7 +122,7 @@ $settings = array(
 	),
 	array(
 		'title'             => __( 'Product Categories - Exclude', 'woocommerce-jetpack' ),
-		'desc'              => __( 'Exclude categories from auto-enabled pre-orders. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to manage category exclusions.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Exclude categories from auto-enabled pre-orders. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to manage category exclusions.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_category_exclude__compare' ) ),
 		'id'                => 'wcj_preorders_auto_enable_categories_exclude',
 		'default'           => array(),
 		'type'              => 'multiselect',
@@ -122,7 +131,7 @@ $settings = array(
 	),
 	array(
 		'title'             => __( 'Products - Include', 'woocommerce-jetpack' ),
-		'desc'              => __( 'Auto-enable pre-orders only for selected products. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock product-level control.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Auto-enable pre-orders only for selected products. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock product-level control.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_product_include__compare' ) ),
 		'id'                => 'wcj_preorders_auto_enable_products_include',
 		'default'           => array(),
 		'type'              => 'multiselect',
@@ -131,7 +140,7 @@ $settings = array(
 	),
 	array(
 		'title'             => __( 'Products - Exclude', 'woocommerce-jetpack' ),
-		'desc'              => __( 'Exclude specific products from pre-orders. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock product exclusions.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Exclude specific products from pre-orders. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock product exclusions.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_product_exclude__compare' ) ),
 		'id'                => 'wcj_preorders_auto_enable_products_exclude',
 		'default'           => array(),
 		'type'              => 'multiselect',
@@ -140,7 +149,7 @@ $settings = array(
 	),
 	array(
 		'title'             => __( 'Default Availability Days', 'woocommerce-jetpack' ),
-		'desc'              => __( 'Set default number of days until release date. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> for customizable availability periods.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Set default number of days until release date. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> for customizable availability periods.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_default_days__compare' ) ),
 		'id'                => 'wcj_preorders_default_availability_days',
 		'default'           => '30',
 		'type'              => 'number',
@@ -148,7 +157,7 @@ $settings = array(
 	),
 	array(
 		'title'             => __( 'Default Price Type', 'woocommerce-jetpack' ),
-		'desc'              => __( 'Set pricing type when auto-enabling pre-orders. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock discount/increase options.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Set pricing type when auto-enabling pre-orders. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock discount/increase options.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_pricing_type__compare' ) ),
 		'id'                => 'wcj_preorders_default_price_type',
 		'default'           => 'default',
 		'type'              => 'select',
@@ -161,7 +170,7 @@ $settings = array(
 	),
 	array(
 		'title'             => __( 'Default Price Adjustment', 'woocommerce-jetpack' ),
-		'desc'              => __( 'Set default discount or markup for pre-orders. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock flexible pricing.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Set default discount or markup for pre-orders. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock flexible pricing.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_pricing_value__compare' ) ),
 		'id'                => 'wcj_preorders_default_price_adjustment',
 		'default'           => '0',
 		'type'              => 'number',
@@ -182,7 +191,7 @@ $settings = array(
 	),
 	array(
 		'title'             => __( 'Pre-order Button Text', 'woocommerce-jetpack' ),
-		'desc'              => __( 'Set custom text for the pre-order button. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock button customization.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Set custom text for the pre-order button. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock button customization.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_button_text__compare' ) ),
 		'id'                => 'wcj_preorders_button_text',
 		'default'           => __( 'Pre-order Now', 'woocommerce-jetpack' ),
 		'type'              => 'text',
@@ -194,7 +203,7 @@ $settings = array(
 		'default'           => '#007cba',
 		'type'              => 'text',
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Choose a background color for pre-order buttons. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock button styling.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Choose a background color for pre-order buttons. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock button styling.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_button_bg__compare' ) ),
 	),
 	array(
 		'title'             => __( 'Button Text Color', 'woocommerce-jetpack' ),
@@ -202,7 +211,7 @@ $settings = array(
 		'default'           => '#ffffff',
 		'type'              => 'text',
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Choose a text color for the pre-order button. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock button text styling.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Choose a text color for the pre-order button. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock button text styling.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_button_text_color__compare' ) ),
 	),
 	array(
 		'title'             => __( 'Button Hover Background Color', 'woocommerce-jetpack' ),
@@ -210,7 +219,7 @@ $settings = array(
 		'default'           => '#0073aa',
 		'type'              => 'text',
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Set background color on button hover. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> for full hover styling.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Set background color on button hover. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> for full hover styling.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_button_hover_bg__compare' ) ),
 	),
 	array(
 		'title'             => __( 'Button Hover Text Color', 'woocommerce-jetpack' ),
@@ -218,7 +227,7 @@ $settings = array(
 		'default'           => '#ffffff',
 		'type'              => 'text',
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Set text color on button hover. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock hover text styling.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Set text color on button hover. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock hover text styling.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_button_hover_text__compare' ) ),
 	),
 	array(
 		'type' => 'sectionend',
@@ -231,7 +240,7 @@ $settings = array(
 	),
 	array(
 		'title'             => __( 'Pre-order Message', 'woocommerce-jetpack' ),
-		'desc'              => __( 'Message shown for pre-order products. Use %release_date% shortcode. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to customize messages.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Message shown for pre-order products. Use %release_date% shortcode. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to customize messages.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_message_text__compare' ) ),
 		'id'                => 'wcj_preorders_message',
 		'default'           => __( 'This item is available for pre-order and will be released on %release_date%.', 'woocommerce-jetpack' ),
 		'type'              => 'text',
@@ -248,7 +257,7 @@ $settings = array(
 			'success' => __( 'Success', 'woocommerce-jetpack' ),
 		),
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Choose style for pre-order messages (custom, notice, success). Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock style options.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Choose style for pre-order messages (custom, notice, success). Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock style options.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_message_style__compare' ) ),
 	),
 	array(
 		'title'             => __( 'Custom Message Text Color', 'woocommerce-jetpack' ),
@@ -256,7 +265,7 @@ $settings = array(
 		'default'           => '#515151',
 		'type'              => 'text',
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Choose custom text color for messages. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> for message styling.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Choose custom text color for messages. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> for message styling.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_message_color__compare' ) ),
 	),
 	array(
 		'id'   => 'wcj_preorders_buttons_tab',
@@ -274,7 +283,7 @@ $settings = array(
 	),
 	array(
 		'title'             => __( 'Enable Free Shipping', 'woocommerce-jetpack' ),
-		'desc'              => __( 'Enable free shipping for pre-order products. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock free shipping rules.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Enable free shipping for pre-order products. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock free shipping rules.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_free_shipping__compare' ) ),
 		'id'                => 'wcj_preorders_free_shipping',
 		'default'           => 'no',
 		'type'              => 'checkbox',
@@ -282,7 +291,7 @@ $settings = array(
 	),
 	array(
 		'title'             => __( 'Free Shipping Label', 'woocommerce-jetpack' ),
-		'desc'              => __( 'Text shown for free shipping. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to customize shipping labels.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Text shown for free shipping. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to customize shipping labels.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_free_shipping_text__compare' ) ),
 		'id'                => 'wcj_preorders_free_shipping_label',
 		'default'           => __( 'Free Shipping (Pre-order)', 'woocommerce-jetpack' ),
 		'type'              => 'text',
@@ -290,7 +299,7 @@ $settings = array(
 	),
 	array(
 		'title'             => __( 'Force Free Shipping Only', 'woocommerce-jetpack' ),
-		'desc'              => __( 'Remove other shipping methods when free shipping is active. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> for shipping control.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Remove other shipping methods when free shipping is active. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> for shipping control.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_shipping_control__compare' ) ),
 		'id'                => 'wcj_preorders_free_shipping_only',
 		'default'           => 'no',
 		'type'              => 'checkbox',
@@ -310,7 +319,7 @@ $settings = array(
 		'default'           => 'no',
 		'type'              => 'checkbox',
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Charge a fee for pre-orders. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock fee management.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Charge a fee for pre-orders. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock fee management.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_fee_enable__compare' ) ),
 	),
 	array(
 		'title'             => __( 'Fee Title', 'woocommerce-jetpack' ),
@@ -318,7 +327,7 @@ $settings = array(
 		'default'           => __( 'Pre-order Fee', 'woocommerce-jetpack' ),
 		'type'              => 'text',
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Fee Title shown in cart/checkout for pre-order fee. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> for customizable labels.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Fee Title shown in cart/checkout for pre-order fee. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> for customizable labels.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_fee_title__compare' ) ),
 	),
 	array(
 		'title'             => __( 'Fee Amount', 'woocommerce-jetpack' ),
@@ -326,7 +335,7 @@ $settings = array(
 		'default'           => '',
 		'type'              => 'number',
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Set global fee amount for pre-orders. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock flexible fee amounts.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Set global fee amount for pre-orders. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock flexible fee amounts.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_fee_amount__compare' ) ),
 	),
 	array(
 		'title'             => __( 'Include Categories', 'woocommerce-jetpack' ),
@@ -381,7 +390,7 @@ $settings = array(
 			'admin_purchase'   => __( 'Admin: New Pre-order Purchase', 'woocommerce-jetpack' ),
 			'customer_confirm' => __( 'Customer: Pre-order Confirmation', 'woocommerce-jetpack' ),
 		),
-		'desc'    => __( 'Keep customers and admins fully informed with dedicated pre-order confirmations, product release updates, and more advanced email options. <br>Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock advanced email notifications.', 'woocommerce-jetpack' ),
+		'desc'    => wcj_replace_booster_url( __( 'Keep customers and admins fully informed with dedicated pre-order confirmations, product release updates, and more advanced email options. <br>Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock advanced email notifications.', 'woocommerce-jetpack' ), $wcj_preorders_compare_url( 'preorders_email_notifications__compare' ) ),
 	),
 	array(
 		'id'   => 'wcj_preorders_email_tab',

--- a/includes/settings/wcj-settings-preorders.php
+++ b/includes/settings/wcj-settings-preorders.php
@@ -16,9 +16,9 @@ if ( function_exists( 'wcj_render_upgrade_block' ) && wcj_has_upgrade_block( 'pr
 	wcj_render_upgrade_block( 'preorders' );
 }
 
-$user_roles   = wcj_get_user_roles_options();
-$product_cats = wcj_get_terms( 'product_cat' );
-$products     = wcj_get_products();
+$user_roles                = wcj_get_user_roles_options();
+$product_cats              = wcj_get_terms( 'product_cat' );
+$products                  = wcj_get_products();
 $wcj_preorders_compare_url = function ( $content ) {
 	return wcj_build_commercial_url(
 		'compare',

--- a/includes/settings/wcj-settings-product-variation-swatches.php
+++ b/includes/settings/wcj-settings-product-variation-swatches.php
@@ -39,7 +39,7 @@ $settings = array(
 	),
 	array(
 		'title'             => __( 'Convert default dropdowns to button', 'woocommerce-jetpack' ),
-		'desc'              => __( 'Want to enable swatches for all your attributes, use button/label swatches, or automatically convert all dropdowns? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank"> Booster Elite </a> for advanced swatch control!', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Want to enable swatches for all your attributes, use button/label swatches, or automatically convert all dropdowns? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank"> Booster Elite </a> for advanced swatch control!', 'woocommerce-jetpack' ), wcj_build_commercial_url( 'compare', array( 'campaign' => 'locked_setting', 'content' => 'variation_swatches_settings__compare' ) ) ),
 		'type'              => 'checkbox',
 		'id'                => 'wcj_product_variation_defualt_to_button',
 		'default'           => 'no',

--- a/includes/settings/wcj-settings-product-variation-swatches.php
+++ b/includes/settings/wcj-settings-product-variation-swatches.php
@@ -39,7 +39,16 @@ $settings = array(
 	),
 	array(
 		'title'             => __( 'Convert default dropdowns to button', 'woocommerce-jetpack' ),
-		'desc'              => wcj_replace_booster_url( __( 'Want to enable swatches for all your attributes, use button/label swatches, or automatically convert all dropdowns? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank"> Booster Elite </a> for advanced swatch control!', 'woocommerce-jetpack' ), wcj_build_commercial_url( 'compare', array( 'campaign' => 'locked_setting', 'content' => 'variation_swatches_settings__compare' ) ) ),
+		'desc'              => wcj_replace_booster_url(
+			__( 'Want to enable swatches for all your attributes, use button/label swatches, or automatically convert all dropdowns? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank"> Booster Elite </a> for advanced swatch control!', 'woocommerce-jetpack' ),
+			wcj_build_commercial_url(
+				'compare',
+				array(
+					'campaign' => 'locked_setting',
+					'content'  => 'variation_swatches_settings__compare',
+				)
+			)
+		),
 		'type'              => 'checkbox',
 		'id'                => 'wcj_product_variation_defualt_to_button',
 		'default'           => 'no',

--- a/includes/settings/wcj-settings-sales-notifications.php
+++ b/includes/settings/wcj-settings-sales-notifications.php
@@ -19,6 +19,16 @@ if ( function_exists( 'wcj_render_upgrade_block' ) && wcj_has_upgrade_block( 'sa
 $products     = wcj_get_products();
 $get_pages    = wcj_get_pages();
 $product_cats = wcj_get_terms( 'product_cat' );
+$wcj_sales_notifications_compare_url = function ( $content ) {
+	return wcj_build_commercial_url(
+		'compare',
+		array(
+			'campaign' => 'locked_setting',
+			'content'  => $content,
+		)
+	);
+};
+
 $settings     = array(
 	array(
 		'id'      => 'wcj_sales_general_options',
@@ -63,7 +73,7 @@ $settings     = array(
 			),
 		'css'               => 'width:100%;height:200px;',
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Customize notification text, add buyer names, country, product prices, images, and time ago etc details. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Customize notification text, add buyer names, country, product prices, images, and time ago etc details. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock.', 'woocommerce-jetpack' ), $wcj_sales_notifications_compare_url( 'sales_notifications_text__compare' ) ),
 		/* translators: %s: product title */
 		'help_text'         => __( 'The message displayed in sales notifications. Use placeholders like %customer_city% and %product_title% to show real purchase details and build social proof.', 'woocommerce-jetpack' ),
 	),
@@ -73,7 +83,7 @@ $settings     = array(
 		'default'           => 'no',
 		'type'              => 'checkbox',
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Enable or disable product image display in notifications. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock this option.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Enable or disable product image display in notifications. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock this option.', 'woocommerce-jetpack' ), $wcj_sales_notifications_compare_url( 'sales_notifications_images__compare' ) ),
 		'help_text'         => __( 'Show product images in notifications to make them more eye-catching and credible. Images help visitors recognize products and increase engagement.', 'woocommerce-jetpack' ),
 		'friendly_label'    => __( 'Show Product Images', 'woocommerce-jetpack' ),
 	),
@@ -88,7 +98,7 @@ $settings     = array(
 			'wcj_both'    => __( 'Both', 'woocommerce-jetpack' ),
 		),
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Choose whether notifications appear on desktop, mobile, or both. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock screen selection.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Choose whether notifications appear on desktop, mobile, or both. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock screen selection.', 'woocommerce-jetpack' ), $wcj_sales_notifications_compare_url( 'sales_notifications_device_targeting__compare' ) ),
 		'help_text'         => __( 'Control which devices show sales notifications. Choose "Both" for maximum reach, or limit to desktop/mobile based on your audience behavior.', 'woocommerce-jetpack' ),
 	),
 	array(
@@ -101,7 +111,7 @@ $settings     = array(
 			'wcj_bottom_left'  => __( 'Bottom Left', 'woocommerce-jetpack' ),
 		),
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Choose where notifications appear on screen. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock Top Right and Top Left positions.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Choose where notifications appear on screen. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock Top Right and Top Left positions.', 'woocommerce-jetpack' ), $wcj_sales_notifications_compare_url( 'sales_notifications_positions__compare' ) ),
 		'help_text'         => __( 'Choose where notifications pop up on the screen. Bottom right is most common and least intrusive, while bottom left works well for RTL languages.', 'woocommerce-jetpack' ),
 	),
 	array(
@@ -126,7 +136,7 @@ $settings     = array(
 		'type'              => 'text',
 		'default'           => '#ffffff',
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Choose a background color for notifications. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock background color customization.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Choose a background color for notifications. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock background color customization.', 'woocommerce-jetpack' ), $wcj_sales_notifications_compare_url( 'sales_notifications_bg_color__compare' ) ),
 	),
 	array(
 		'title'             => __( 'Text Color', 'woocommerce-jetpack' ),
@@ -134,7 +144,7 @@ $settings     = array(
 		'type'              => 'text',
 		'default'           => '#000000',
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Customize the text color of your notifications. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock text color customization.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Customize the text color of your notifications. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock text color customization.', 'woocommerce-jetpack' ), $wcj_sales_notifications_compare_url( 'sales_notifications_text_color__compare' ) ),
 	),
 	array(
 		'title'             => __( 'Display Effect', 'woocommerce-jetpack' ),
@@ -149,7 +159,7 @@ $settings     = array(
 			'wcj_slideindown'  => __( 'SlideInDown', 'woocommerce-jetpack' ),
 		),
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Select how notifications should appear (fade, slide, etc.). Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock animation effects.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Select how notifications should appear (fade, slide, etc.). Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock animation effects.', 'woocommerce-jetpack' ), $wcj_sales_notifications_compare_url( 'sales_notifications_show_effect__compare' ) ),
 	),
 	array(
 		'title'             => __( 'Hidden Effect', 'woocommerce-jetpack' ),
@@ -164,7 +174,7 @@ $settings     = array(
 			'wcj_slideoutdown'  => __( 'SlideOutDown', 'woocommerce-jetpack' ),
 		),
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Select how notifications should disappear (fade, slide, etc.). Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock hiding effects.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Select how notifications should disappear (fade, slide, etc.). Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock hiding effects.', 'woocommerce-jetpack' ), $wcj_sales_notifications_compare_url( 'sales_notifications_hide_effect__compare' ) ),
 	),
 	array(
 		'id'   => 'wcj_sales_styling_tab',
@@ -181,7 +191,7 @@ $settings     = array(
 		'default'           => '4',
 		'step'              => '1',
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Set how long each notification stays visible (in seconds). Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock duration control.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Set how long each notification stays visible (in seconds). Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock duration control.', 'woocommerce-jetpack' ), $wcj_sales_notifications_compare_url( 'sales_notifications_duration__compare' ) ),
 		'help_text'         => __( 'How long each notification stays visible before disappearing. Most stores use 4-6 seconds - long enough to read but not annoying.', 'woocommerce-jetpack' ),
 		'friendly_label'    => __( 'Display Duration', 'woocommerce-jetpack' ),
 	),
@@ -192,7 +202,7 @@ $settings     = array(
 		'default'           => '8',
 		'step'              => '1',
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Set delay before the next notification appears (in seconds). Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock timing options.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Set delay before the next notification appears (in seconds). Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock timing options.', 'woocommerce-jetpack' ), $wcj_sales_notifications_compare_url( 'sales_notifications_delay__compare' ) ),
 		'help_text'         => __( 'Time to wait before showing the next notification. Use 8-15 seconds to avoid overwhelming visitors with too many popups.', 'woocommerce-jetpack' ),
 		'friendly_label'    => __( 'Delay Between Notifications', 'woocommerce-jetpack' ),
 	),
@@ -210,7 +220,7 @@ $settings     = array(
 		'default'           => 'processing, completed',
 		'type'              => 'text',
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Want to show notifications for various order statuses like "Shipped" or "Refunded" to build trust and keep customers informed? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock all order statuses.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Want to show notifications for various order statuses like "Shipped" or "Refunded" to build trust and keep customers informed? Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock all order statuses.', 'woocommerce-jetpack' ), $wcj_sales_notifications_compare_url( 'sales_notifications_statuses__compare' ) ),
 		'help_text'         => __( 'Which order statuses to show in notifications. Use "processing, completed" to show confirmed purchases. Avoid showing pending or failed orders.', 'woocommerce-jetpack' ),
 	),
 	array(
@@ -227,7 +237,7 @@ $settings     = array(
 		'default'           => 'no',
 		'type'              => 'checkbox',
 		'custom_attributes' => apply_filters( 'booster_message', '', 'disabled' ),
-		'desc'              => __( 'Play a sound when a sales notification appears like Beep, Doublebeep etc. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock sound effects.', 'woocommerce-jetpack' ),
+		'desc'              => wcj_replace_booster_url( __( 'Play a sound when a sales notification appears like Beep, Doublebeep etc. Upgrade to <a href="https://booster.io/buy-booster/" target="_blank">Booster</a> to unlock sound effects.', 'woocommerce-jetpack' ), $wcj_sales_notifications_compare_url( 'sales_notifications_sound__compare' ) ),
 	),
 	array(
 		'title'             => __( 'Sound', 'woocommerce-jetpack' ),

--- a/includes/settings/wcj-settings-sales-notifications.php
+++ b/includes/settings/wcj-settings-sales-notifications.php
@@ -16,9 +16,9 @@ if ( function_exists( 'wcj_render_upgrade_block' ) && wcj_has_upgrade_block( 'sa
 	wcj_render_upgrade_block( 'sales_notifications' );
 }
 
-$products     = wcj_get_products();
-$get_pages    = wcj_get_pages();
-$product_cats = wcj_get_terms( 'product_cat' );
+$products                            = wcj_get_products();
+$get_pages                           = wcj_get_pages();
+$product_cats                        = wcj_get_terms( 'product_cat' );
 $wcj_sales_notifications_compare_url = function ( $content ) {
 	return wcj_build_commercial_url(
 		'compare',
@@ -29,7 +29,7 @@ $wcj_sales_notifications_compare_url = function ( $content ) {
 	);
 };
 
-$settings     = array(
+$settings = array(
 	array(
 		'id'      => 'wcj_sales_general_options',
 		'type'    => 'tab_ids',

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: woocommerce, abandoned cart, cart recovery, swatches, woocommerce pdf invo
 Requires at least: 5.8
 Tested up to: 6.9
 Requires PHP: 7.2
-Stable tag: 7.11.3
+Stable tag: 7.11.4
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -346,6 +346,14 @@ No. Onboarding analytics are local-only (apply/undo/mode views) to improve the e
 * For support please visit the [Plugin Support Forum](https://wordpress.org/support/plugin/woocommerce-jetpack/).
 
 == Changelog ==
+
+= 7.11.4 - 14/03/2026 =
+* Normalized in-plugin upsell routing so generic compare-first prompts route to /free-vs-elite/ while explicit buy/pricing CTAs stay on /buy-booster/.
+* Kept upgrade-block comparison buttons and other ambiguous/tag-first docs/features/about assists on their current destinations while separating account, support, update, and download routes from generic sales flows.
+* Normalized Booster in-plugin source and UTM tagging across the scoped admin surfaces.
+* Confirmed no direct-checkout plugin CTA was introduced in this release candidate.
+* WooCommerce 10.5.3 Tested
+* WordPress 6.9.1 Tested
 
 = 7.11.3 - 11/03/2026 =
 * Improved goal discovery and blueprint selection flow for a faster setup experience.

--- a/readme.txt
+++ b/readme.txt
@@ -347,12 +347,12 @@ No. Onboarding analytics are local-only (apply/undo/mode views) to improve the e
 
 == Changelog ==
 
-= 7.11.4 - 14/03/2026 =
+= 7.11.4 - 18/03/2026 =
 * Normalized in-plugin upsell routing so generic compare-first prompts route to /free-vs-elite/ while explicit buy/pricing CTAs stay on /buy-booster/.
 * Kept upgrade-block comparison buttons and other ambiguous/tag-first docs/features/about assists on their current destinations while separating account, support, update, and download routes from generic sales flows.
 * Normalized Booster in-plugin source and UTM tagging across the scoped admin surfaces.
 * Confirmed no direct-checkout plugin CTA was introduced in this release candidate.
-* WooCommerce 10.5.3 Tested
+* WooCommerce 10.6.1 Tested
 * WordPress 6.9.1 Tested
 
 = 7.11.3 - 11/03/2026 =

--- a/version-details.json
+++ b/version-details.json
@@ -1,9 +1,9 @@
 {
-    "0": "= 7.11.3 - 11/03/2026 =",
-    "1": "* **Improved onboarding flow** with faster goal discovery and refined blueprint selection for quicker setup.",
-    "2": "* **Enhanced success guidance** and goal-specific next-step metadata for cart recovery and completion states.",
-    "3": "* **Improved accessibility and UX** featuring better keyboard navigation, ARIA semantics, and modal focus handling.",
-    "4": "* **Internal telemetry updates** for lifecycle event logging and improved metadata payloads in local environments.",
+    "0": "= 7.11.4 - 14/03/2026 =",
+    "1": "* Normalized in-plugin upsell routing so generic compare-first prompts route to /free-vs-elite/ while explicit buy/pricing CTAs stay on /buy-booster/.",
+    "2": "* Kept upgrade-block comparison buttons and other ambiguous/tag-first docs/features/about assists on their current destinations while separating account, support, update, and download routes from generic sales flows.",
+    "3": "* Normalized Booster in-plugin source and UTM tagging across the scoped admin surfaces.",
+    "4": "* Confirmed no direct-checkout plugin CTA was introduced in this release candidate.",
     "5": "* WooCommerce 10.5.3 Tested",
     "6": "* WordPress 6.9.1 Tested"
 }

--- a/version-details.json
+++ b/version-details.json
@@ -1,9 +1,9 @@
 {
-    "0": "= 7.11.4 - 14/03/2026 =",
+    "0": "= 7.11.4 - 18/03/2026 =",
     "1": "* Normalized in-plugin upsell routing so generic compare-first prompts route to /free-vs-elite/ while explicit buy/pricing CTAs stay on /buy-booster/.",
     "2": "* Kept upgrade-block comparison buttons and other ambiguous/tag-first docs/features/about assists on their current destinations while separating account, support, update, and download routes from generic sales flows.",
     "3": "* Normalized Booster in-plugin source and UTM tagging across the scoped admin surfaces.",
     "4": "* Confirmed no direct-checkout plugin CTA was introduced in this release candidate.",
-    "5": "* WooCommerce 10.5.3 Tested",
+    "5": "* WooCommerce 10.6.1 Tested",
     "6": "* WordPress 6.9.1 Tested"
 }

--- a/woocommerce-jetpack.php
+++ b/woocommerce-jetpack.php
@@ -4,7 +4,7 @@
  * Requires Plugins: woocommerce
  * Plugin URI: https://booster.io
  * Description: Supercharge your WooCommerce site with these awesome powerful features.
- * Version: 7.11.3
+ * Version: 7.11.4
  * Author: Pluggabl LLC
  * Author URI: https://booster.io
  * Text Domain: woocommerce-jetpack
@@ -72,7 +72,7 @@ if ( ! class_exists( 'WC_Jetpack' ) ) :
 		 *
 		 * @var string
 		 */
-		public $version = '7.11.3';
+		public $version = '7.11.4';
 
 		/**
 		 * Singleton instance.

--- a/woocommerce-jetpack.php
+++ b/woocommerce-jetpack.php
@@ -9,7 +9,7 @@
  * Author URI: https://booster.io
  * Text Domain: woocommerce-jetpack
  * Domain Path: /langs
- * WC tested up to: 10.5.3
+ * WC tested up to: 10.6.1
  * License: GNU General Public License v3.0
  *
  * @package Booster_For_WooCommerce


### PR DESCRIPTION
= 7.11.4 - 18/03/2026 =
* Normalized in-plugin upsell routing so generic compare-first prompts route to /free-vs-elite/ while explicit buy/pricing CTAs stay on /buy-booster/.
* Kept upgrade-block comparison buttons and other ambiguous/tag-first docs/features/about assists on their current destinations while separating account, support, update, and download routes from generic sales flows.
* Normalized Booster in-plugin source and UTM tagging across the scoped admin surfaces.
* Confirmed no direct-checkout plugin CTA was introduced in this release candidate.
* WooCommerce 10.6.1 Tested
* WordPress 6.9.1 Tested