### PR TITLE
v7.11.5

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,14 @@
 == Changelog ==
 
+= 7.11.5 - 01/04/2026 =
+* Feature - WooCommerce Blocks: Added support for Checkout Custom Fields (Text, Select, and Checkbox) via the WC Additional Checkout Fields API.
+* Enhancement - Performance: Optimized Admin JS loading; wcj-admin.js is now scoped strictly to Booster and WooCommerce Order pages.
+* Fix - HPOS Compatibility: Updated Store Exporter and Order Display to use WC CRUD API for custom fields when High-Performance Order Storage is enabled.
+* Fix - Blocks Integration: Implemented a meta bridge to ensure Block-based checkout data is correctly mapped to Booster's legacy format (label-based storage).
+* Fix - HPOS: Removed redundant legacy get_post_meta calls when viewing orders in HPOS mode.
+* WooCommerce 10.6.1 Tested
+* WordPress 6.9.4 Tested
+
 = 7.11.4 - 18/03/2026 =
 * Normalized in-plugin upsell routing so generic compare-first prompts route to /free-vs-elite/ while explicit buy/pricing CTAs stay on /buy-booster/.
 * Kept upgrade-block comparison buttons and other ambiguous/tag-first docs/features/about assists on their current destinations while separating account, support, update, and download routes from generic sales flows.

--- a/includes/admin/class-wc-settings-jetpack.php
+++ b/includes/admin/class-wc-settings-jetpack.php
@@ -229,6 +229,10 @@ if ( ! class_exists( 'WC_Settings_Jetpack' ) ) :
 		 * @since   5.4.2
 		 */
 		public function enqueue_admin_script() {
+			$screen = get_current_screen();
+			if ( $screen && false === strpos( $screen->id, 'wcj' ) && false === strpos( $screen->id, 'woocommerce' ) && false === strpos( $screen->id, 'booster' ) && 'shop_order' !== $screen->id && 'woocommerce_page_wc-orders' !== $screen->id ) {
+				return;
+			}
 			wp_enqueue_script( 'wcj-admin-js', trailingslashit( wcj_plugin_url() ) . 'includes/js/wcj-admin.js', array( 'jquery' ), w_c_j()->version, true );
 			wp_localize_script( 'wcj-admin-js', 'admin_object', array( 'admin_object' ), false );
 		}

--- a/includes/admin/class-wcj-welcome.php
+++ b/includes/admin/class-wcj-welcome.php
@@ -101,6 +101,10 @@ if ( ! class_exists( 'WCJ_Welcome' ) ) :
 		 * @since   5.4.3
 		 */
 		public function enqueue_admin_script() {
+			$screen = get_current_screen();
+			if ( $screen && false === strpos( $screen->id, 'wcj' ) && false === strpos( $screen->id, 'woocommerce' ) && false === strpos( $screen->id, 'booster' ) && 'shop_order' !== $screen->id && 'woocommerce_page_wc-orders' !== $screen->id ) {
+				return;
+			}
 			wp_enqueue_script( 'wcj-admin-js', trailingslashit( wcj_plugin_url() ) . 'includes/js/wcj-admin.js', array( 'jquery' ), w_c_j()->version, true );
 			wp_localize_script( 'wcj-admin-js', 'admin_object', array( 'admin_object' ), false );
 		}

--- a/includes/class-wcj-checkout-custom-fields-blocks.php
+++ b/includes/class-wcj-checkout-custom-fields-blocks.php
@@ -172,6 +172,38 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 		}
 
 		/**
+		 * Reverse-map a Blocks select slug back to the raw Booster option label.
+		 *
+		 * During registration, raw Booster option labels are converted to slugs
+		 * via sanitize_title(). This reverses that mapping so the bridged meta
+		 * stores the same raw label that the classic checkout path would store.
+		 *
+		 * @version 7.12.0
+		 * @since   7.12.0
+		 * @param int    $field_index Booster field index.
+		 * @param string $slug        The sanitized slug submitted by Blocks checkout.
+		 * @return string The raw Booster option label, or the slug if no match found.
+		 */
+		private function reverse_map_select_value( $field_index, $slug ) {
+			$options_raw = wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $field_index, '' );
+			if ( '' === $options_raw ) {
+				return $slug;
+			}
+
+			$lines = array_map( 'trim', explode( PHP_EOL, $options_raw ) );
+			foreach ( $lines as $line ) {
+				if ( '' === $line ) {
+					continue;
+				}
+				if ( urldecode( sanitize_title( $line ) ) === $slug ) {
+					return $line;
+				}
+			}
+
+			return $slug;
+		}
+
+		/**
 		 * Bridge WC Blocks meta to Booster meta format after a Blocks checkout.
 		 *
 		 * When a customer checks out via WooCommerce Blocks, field data is saved
@@ -217,6 +249,13 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 				// Normalize checkbox values: WC Blocks stores true/false, Booster stores 1/0.
 				if ( 'checkbox' === $booster_type ) {
 					$blocks_value = ! empty( $blocks_value ) ? 1 : 0;
+				}
+
+				// Reverse-map select slug back to the raw Booster option label.
+				// Blocks submits the sanitized slug (e.g. "express-delivery") but
+				// Booster's classic path stores the raw option text ("Express Delivery").
+				if ( 'select' === $booster_type ) {
+					$blocks_value = $this->reverse_map_select_value( $i, $blocks_value );
 				}
 
 				$order->update_meta_data( $booster_key, $blocks_value );

--- a/includes/class-wcj-checkout-custom-fields-blocks.php
+++ b/includes/class-wcj-checkout-custom-fields-blocks.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * Booster for WooCommerce - Checkout Custom Fields - WooCommerce Blocks Integration
+ *
+ * Registers Booster checkout custom fields with the WooCommerce Blocks checkout
+ * and bridges Blocks-saved data back to Booster meta format so that existing
+ * admin display, email, shortcode, and exporter code continues to work.
+ *
+ * Supported field types on Blocks checkout: text, select, checkbox.
+ * Unsupported types (textarea, radio, datepicker, etc.) are silently skipped
+ * and continue to work only on classic checkout.
+ *
+ * @version 7.12.0
+ * @since   7.12.0
+ * @author  Pluggabl LLC.
+ * @package Booster_For_WooCommerce/includes
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
+
+	/**
+	 * WCJ_Checkout_Custom_Fields_Blocks.
+	 *
+	 * @version 7.12.0
+	 * @since   7.12.0
+	 */
+	class WCJ_Checkout_Custom_Fields_Blocks {
+
+		/**
+		 * Namespace prefix for WC Blocks field IDs.
+		 *
+		 * @var string
+		 */
+		const FIELD_NAMESPACE = 'booster-wcj';
+
+		/**
+		 * Total number of checkout custom fields configured.
+		 *
+		 * @var int
+		 */
+		private $total_fields;
+
+		/**
+		 * Field types supported on WooCommerce Blocks checkout.
+		 *
+		 * @var array
+		 */
+		private $supported_types = array( 'text', 'select', 'checkbox' );
+
+		/**
+		 * Constructor.
+		 *
+		 * @version 7.12.0
+		 * @since   7.12.0
+		 * @param int $total_fields Total number of configured checkout custom fields.
+		 */
+		public function __construct( $total_fields ) {
+			$this->total_fields = $total_fields;
+
+			add_action( 'woocommerce_init', array( $this, 'register_blocks_checkout_fields' ) );
+			add_action( 'woocommerce_store_api_checkout_order_processed', array( $this, 'bridge_blocks_meta_to_booster_format' ) );
+		}
+
+		/**
+		 * Check if the WC Blocks additional checkout fields API is available.
+		 *
+		 * @version 7.12.0
+		 * @since   7.12.0
+		 * @return bool
+		 */
+		private function is_blocks_api_available() {
+			return function_exists( 'woocommerce_register_additional_checkout_field' );
+		}
+
+		/**
+		 * Get the WC Blocks field ID for a given Booster field index.
+		 *
+		 * @version 7.12.0
+		 * @since   7.12.0
+		 * @param int $field_index Booster field index.
+		 * @return string
+		 */
+		private function get_blocks_field_id( $field_index ) {
+			return self::FIELD_NAMESPACE . '/checkout-field-' . $field_index;
+		}
+
+		/**
+		 * Register Booster checkout custom fields with the WC Blocks API.
+		 *
+		 * Only registers fields with supported types (text, select, checkbox).
+		 * All fields use the 'order' location so they appear in the
+		 * "Additional Information" section on the Blocks checkout.
+		 *
+		 * @version 7.12.0
+		 * @since   7.12.0
+		 */
+		public function register_blocks_checkout_fields() {
+			if ( ! $this->is_blocks_api_available() ) {
+				return;
+			}
+
+			for ( $i = 1; $i <= $this->total_fields; $i++ ) {
+				if ( 'yes' !== wcj_get_option( 'wcj_checkout_custom_field_enabled_' . $i ) ) {
+					continue;
+				}
+
+				$booster_type = wcj_get_option( 'wcj_checkout_custom_field_type_' . $i, 'text' );
+				if ( ! in_array( $booster_type, $this->supported_types, true ) ) {
+					continue;
+				}
+
+				$label    = wcj_get_option( 'wcj_checkout_custom_field_label_' . $i, '' );
+				$required = ( 'yes' === wcj_get_option( 'wcj_checkout_custom_field_required_' . $i, 'no' ) );
+
+				$field_args = array(
+					'id'       => $this->get_blocks_field_id( $i ),
+					'label'    => $label,
+					'location' => 'order',
+					'type'     => $booster_type,
+					'required' => $required,
+				);
+
+				if ( 'select' === $booster_type ) {
+					$options_raw            = wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $i, '' );
+					$field_args['options']  = $this->format_select_options_for_blocks( $options_raw );
+				}
+
+				if ( 'text' === $booster_type ) {
+					$placeholder = wcj_get_option( 'wcj_checkout_custom_field_placeholder_' . $i, '' );
+					if ( '' !== $placeholder ) {
+						$field_args['attributes'] = array( 'placeholder' => $placeholder );
+					}
+				}
+
+				woocommerce_register_additional_checkout_field( $field_args );
+			}
+		}
+
+		/**
+		 * Convert Booster's newline-separated select options to the WC Blocks format.
+		 *
+		 * Booster stores select options as a newline-separated string.
+		 * WC Blocks expects an array of { label, value } arrays.
+		 *
+		 * @version 7.12.0
+		 * @since   7.12.0
+		 * @param string $options_raw Newline-separated options from Booster settings.
+		 * @return array
+		 */
+		private function format_select_options_for_blocks( $options_raw ) {
+			$blocks_options = array();
+			if ( '' === $options_raw ) {
+				return $blocks_options;
+			}
+
+			$lines = array_map( 'trim', explode( PHP_EOL, $options_raw ) );
+			foreach ( $lines as $line ) {
+				if ( '' === $line ) {
+					continue;
+				}
+				$blocks_options[] = array(
+					'label' => $line,
+					'value' => urldecode( sanitize_title( $line ) ),
+				);
+			}
+
+			return $blocks_options;
+		}
+
+		/**
+		 * Bridge WC Blocks meta to Booster meta format after a Blocks checkout.
+		 *
+		 * When a customer checks out via WooCommerce Blocks, field data is saved
+		 * using the Blocks meta key format (_wc_other/booster-wcj/checkout-field-N).
+		 * This method copies that data into Booster's expected meta key format
+		 * (_SECTION_wcj_checkout_field_N) so that existing admin order display,
+		 * emails, shortcodes, and store exporters continue to work.
+		 *
+		 * @version 7.12.0
+		 * @since   7.12.0
+		 * @param \WC_Order $order The order object.
+		 */
+		public function bridge_blocks_meta_to_booster_format( $order ) {
+			$bridged_any = false;
+
+			for ( $i = 1; $i <= $this->total_fields; $i++ ) {
+				if ( 'yes' !== wcj_get_option( 'wcj_checkout_custom_field_enabled_' . $i ) ) {
+					continue;
+				}
+
+				$booster_type = wcj_get_option( 'wcj_checkout_custom_field_type_' . $i, 'text' );
+				if ( ! in_array( $booster_type, $this->supported_types, true ) ) {
+					continue;
+				}
+
+				$field_id       = $this->get_blocks_field_id( $i );
+				$blocks_meta_key = '_wc_other/' . $field_id;
+				$blocks_value    = $order->get_meta( $blocks_meta_key );
+
+				if ( '' === $blocks_value ) {
+					if ( 'checkbox' !== $booster_type ) {
+						continue;
+					}
+				}
+
+				$section = wcj_get_option( 'wcj_checkout_custom_field_section_' . $i, 'billing' );
+				$label   = wcj_get_option( 'wcj_checkout_custom_field_label_' . $i, '' );
+
+				$booster_key       = '_' . $section . '_wcj_checkout_field_' . $i;
+				$booster_key_label = '_' . $section . '_wcj_checkout_field_label_' . $i;
+				$booster_key_type  = '_' . $section . '_wcj_checkout_field_type_' . $i;
+
+				// Normalize checkbox values: WC Blocks stores true/false, Booster stores 1/0.
+				if ( 'checkbox' === $booster_type ) {
+					$blocks_value = ! empty( $blocks_value ) ? 1 : 0;
+				}
+
+				$order->update_meta_data( $booster_key, $blocks_value );
+				$order->update_meta_data( $booster_key_label, $label );
+				$order->update_meta_data( $booster_key_type, $booster_type );
+
+				// Store checkbox display text.
+				if ( 'checkbox' === $booster_type ) {
+					$checkbox_key   = '_' . $section . '_wcj_checkout_field_checkbox_value_' . $i;
+					$checkbox_value = ( 1 === (int) $blocks_value )
+						? get_option( 'wcj_checkout_custom_field_checkbox_yes_' . $i, '' )
+						: get_option( 'wcj_checkout_custom_field_checkbox_no_' . $i, '' );
+					$order->update_meta_data( $checkbox_key, $checkbox_value );
+				}
+
+				// Store select options string for display resolution.
+				if ( 'select' === $booster_type ) {
+					$select_key = '_' . $section . '_wcj_checkout_field_select_options_' . $i;
+					$the_values = wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $i, '' );
+					$order->update_meta_data( $select_key, $the_values );
+				}
+
+				$bridged_any = true;
+			}
+
+			if ( $bridged_any ) {
+				$order->save();
+			}
+		}
+	}
+
+endif;

--- a/includes/class-wcj-checkout-custom-fields-blocks.php
+++ b/includes/class-wcj-checkout-custom-fields-blocks.php
@@ -93,7 +93,7 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 		 *
 		 * Only registers fields with supported types (text, select, checkbox).
 		 * All fields use the 'order' location so they appear in the
-		 * "Additional Information" section on the Blocks checkout.
+		 * order/additional-information area of the Checkout block.
 		 *
 		 * @version 7.12.0
 		 * @since   7.12.0
@@ -125,16 +125,12 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 				);
 
 				if ( 'select' === $booster_type ) {
-					$options_raw            = wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $i, '' );
-					$field_args['options']  = $this->format_select_options_for_blocks( $options_raw );
+					$options_raw           = wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $i, '' );
+					$field_args['options'] = $this->format_select_options_for_blocks( $options_raw );
 				}
 
-				if ( 'text' === $booster_type ) {
-					$placeholder = wcj_get_option( 'wcj_checkout_custom_field_placeholder_' . $i, '' );
-					if ( '' !== $placeholder ) {
-						$field_args['attributes'] = array( 'placeholder' => $placeholder );
-					}
-				}
+				// Note: WC Blocks API does not support 'placeholder' for text fields.
+				// Select 'placeholder' is a top-level param but is optional.
 
 				woocommerce_register_additional_checkout_field( $field_args );
 			}
@@ -204,11 +200,31 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 		}
 
 		/**
+		 * Get the WC Blocks CheckoutFields service instance.
+		 *
+		 * @version 7.12.0
+		 * @since   7.12.0
+		 * @return object|false The CheckoutFields service or false if unavailable.
+		 */
+		private function get_checkout_fields_service() {
+			if ( ! class_exists( 'Automattic\WooCommerce\Blocks\Package' ) ) {
+				return false;
+			}
+			try {
+				$container = \Automattic\WooCommerce\Blocks\Package::container();
+				return $container->get( \Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields::class );
+			} catch ( \Exception $e ) {
+				return false;
+			}
+		}
+
+		/**
 		 * Bridge WC Blocks meta to Booster meta format after a Blocks checkout.
 		 *
 		 * When a customer checks out via WooCommerce Blocks, field data is saved
-		 * using the Blocks meta key format (_wc_other/booster-wcj/checkout-field-N).
-		 * This method copies that data into Booster's expected meta key format
+		 * by the Store API using the Blocks meta key format. This method reads
+		 * that data using the WC CheckoutFields service (the recommended access
+		 * path) and copies it into Booster's expected meta key format
 		 * (_SECTION_wcj_checkout_field_N) so that existing admin order display,
 		 * emails, shortcodes, and store exporters continue to work.
 		 *
@@ -217,7 +233,8 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 		 * @param \WC_Order $order The order object.
 		 */
 		public function bridge_blocks_meta_to_booster_format( $order ) {
-			$bridged_any = false;
+			$checkout_fields_service = $this->get_checkout_fields_service();
+			$bridged_any             = false;
 
 			for ( $i = 1; $i <= $this->total_fields; $i++ ) {
 				if ( 'yes' !== wcj_get_option( 'wcj_checkout_custom_field_enabled_' . $i ) ) {
@@ -229,14 +246,26 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 					continue;
 				}
 
-				$field_id       = $this->get_blocks_field_id( $i );
-				$blocks_meta_key = '_wc_other/' . $field_id;
-				$blocks_value    = $order->get_meta( $blocks_meta_key );
+				$field_id     = $this->get_blocks_field_id( $i );
+				$blocks_value = '';
 
-				if ( '' === $blocks_value ) {
+				// Use the WC CheckoutFields service (recommended) to read the value.
+				if ( $checkout_fields_service && method_exists( $checkout_fields_service, 'get_field_from_object' ) ) {
+					$blocks_value = $checkout_fields_service->get_field_from_object( $field_id, $order, 'other' );
+				}
+
+				// Fallback: try direct meta read if the service returned empty.
+				if ( '' === $blocks_value || false === $blocks_value || null === $blocks_value ) {
+					$blocks_meta_key = '_wc_other/' . $field_id;
+					$blocks_value    = $order->get_meta( $blocks_meta_key );
+				}
+
+				// Skip fields with no value (except checkboxes which can be unchecked).
+				if ( '' === $blocks_value || false === $blocks_value || null === $blocks_value ) {
 					if ( 'checkbox' !== $booster_type ) {
 						continue;
 					}
+					$blocks_value = '';
 				}
 
 				$section = wcj_get_option( 'wcj_checkout_custom_field_section_' . $i, 'billing' );
@@ -246,14 +275,12 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 				$booster_key_label = '_' . $section . '_wcj_checkout_field_label_' . $i;
 				$booster_key_type  = '_' . $section . '_wcj_checkout_field_type_' . $i;
 
-				// Normalize checkbox values: WC Blocks stores true/false, Booster stores 1/0.
+				// Normalize checkbox values: WC Blocks stores "true"/"false" or "1"/"0", Booster stores 1/0.
 				if ( 'checkbox' === $booster_type ) {
-					$blocks_value = ! empty( $blocks_value ) ? 1 : 0;
+					$blocks_value = ( ! empty( $blocks_value ) && 'false' !== $blocks_value && '0' !== $blocks_value ) ? 1 : 0;
 				}
 
 				// Reverse-map select slug back to the raw Booster option label.
-				// Blocks submits the sanitized slug (e.g. "express-delivery") but
-				// Booster's classic path stores the raw option text ("Express Delivery").
 				if ( 'select' === $booster_type ) {
 					$blocks_value = $this->reverse_map_select_value( $i, $blocks_value );
 				}

--- a/includes/class-wcj-checkout-custom-fields.php
+++ b/includes/class-wcj-checkout-custom-fields.php
@@ -223,7 +223,8 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields' ) ) :
 							if ( false !== strpos( $key, '_label_' ) ) {
 								continue;
 							}
-							$order->$key = $meta_data_array['value'];
+							$meta_value  = $meta_data_array['value'];
+							$order->$key = is_array( $meta_value ) && isset( $meta_value['value'] ) ? $meta_value['value'] : $meta_value;
 						}
 					}
 				}

--- a/includes/class-wcj-checkout-custom-fields.php
+++ b/includes/class-wcj-checkout-custom-fields.php
@@ -98,6 +98,10 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields' ) ) :
 
 				// Update checkout fields from admin on a subscription order.
 				add_action( 'save_post_shop_subscription', array( $this, 'update_custom_checkout_fields_order_meta' ) );
+
+				// WooCommerce Blocks checkout integration.
+				require_once WCJ_FREE_PLUGIN_PATH . '/includes/class-wcj-checkout-custom-fields-blocks.php';
+				new WCJ_Checkout_Custom_Fields_Blocks( $this->wcj_checkout_custom_fields_total_number );
 			}
 		}
 

--- a/includes/class-wcj-checkout-custom-fields.php
+++ b/includes/class-wcj-checkout-custom-fields.php
@@ -213,13 +213,29 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields' ) ) :
 		 * @param string $order_id defines the order_id.
 		 */
 		public function add_custom_fields_to_store_exporter_order( $order, $order_id ) {
-			$post_meta = get_post_meta( $order_id );
-			foreach ( $post_meta as $key => $values ) {
-				if ( false !== strpos( $key, 'wcj_checkout_field_' ) && isset( $values[0] ) ) {
-					if ( false !== strpos( $key, '_label_' ) ) {
-						continue;
+			if ( true === wcj_is_hpos_enabled() ) {
+				$wc_order = wcj_get_order( $order_id );
+				if ( $wc_order && false !== $wc_order ) {
+					foreach ( $wc_order->get_meta_data() as $meta_data_obj ) {
+						$meta_data_array = $meta_data_obj->get_data();
+						$key             = $meta_data_array['key'];
+						if ( false !== strpos( $key, 'wcj_checkout_field_' ) ) {
+							if ( false !== strpos( $key, '_label_' ) ) {
+								continue;
+							}
+							$order->$key = $meta_data_array['value'];
+						}
 					}
-					$order->$key = isset( $values[0]['value'] ) ? $values[0]['value'] : $values[0];
+				}
+			} else {
+				$post_meta = get_post_meta( $order_id );
+				foreach ( $post_meta as $key => $values ) {
+					if ( false !== strpos( $key, 'wcj_checkout_field_' ) && isset( $values[0] ) ) {
+						if ( false !== strpos( $key, '_label_' ) ) {
+							continue;
+						}
+						$order->$key = isset( $values[0]['value'] ) ? $values[0]['value'] : $values[0];
+					}
 				}
 			}
 
@@ -371,13 +387,14 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields' ) ) :
 		 * @param string $templates defines the templates.
 		 */
 		public function add_custom_fields_to_order_display( $order, string $section = null, $templates ) {
-			$post_meta = get_post_meta( wcj_get_order_id( $order ) );
 			if ( true === wcj_is_hpos_enabled() ) {
 				$post_meta = array();
 				foreach ( $order->get_meta_data() as $meta_data_obj ) {
 					$meta_data_array                      = $meta_data_obj->get_data();
 					$post_meta[ $meta_data_array['key'] ] = array( $meta_data_array['value'] );
 				}
+			} else {
+				$post_meta = get_post_meta( wcj_get_order_id( $order ) );
 			}
 			$final_output = '';
 			foreach ( $post_meta as $key => $values ) {

--- a/includes/class-wcj-checkout-custom-fields.php
+++ b/includes/class-wcj-checkout-custom-fields.php
@@ -961,7 +961,6 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields' ) ) :
 			}
 				return $value;
 		}
-
 	}
 
 endif;

--- a/includes/core/class-wcj-admin.php
+++ b/includes/core/class-wcj-admin.php
@@ -301,6 +301,10 @@ if ( ! class_exists( 'WCJ_Admin' ) ) :
 		 * @since  1.0.0
 		 */
 		public function enqueue_admin_script() {
+			$screen = get_current_screen();
+			if ( $screen && false === strpos( $screen->id, 'wcj' ) && false === strpos( $screen->id, 'woocommerce' ) && false === strpos( $screen->id, 'booster' ) && 'shop_order' !== $screen->id && 'woocommerce_page_wc-orders' !== $screen->id ) {
+				return;
+			}
 			wp_enqueue_script( 'wcj-admin-js', trailingslashit( wcj_plugin_url() ) . 'includes/js/wcj-admin.js', array( 'jquery' ), w_c_j()->version, true );
 			wp_localize_script(
 				'wcj-admin-js',

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: pluggabl, ronyp, gravid7
 Donate link: https://booster.io/
 Tags: woocommerce, abandoned cart, cart recovery, swatches, woocommerce pdf invoices, variation swatches, woocommerce multi currency, woocommerce dynamic pricing, woocommerce checkout fields, woocommerce product addons, woocommerce product feed, currency switcher
 Requires at least: 5.8
-Tested up to: 6.9
+Tested up to: 6.9.4
 Requires PHP: 7.2
-Stable tag: 7.11.4
+Stable tag: 7.11.5
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -346,6 +346,15 @@ No. Onboarding analytics are local-only (apply/undo/mode views) to improve the e
 * For support please visit the [Plugin Support Forum](https://wordpress.org/support/plugin/woocommerce-jetpack/).
 
 == Changelog ==
+
+= 7.11.5 - 01/04/2026 =
+* Feature - WooCommerce Blocks: Added support for Checkout Custom Fields (Text, Select, and Checkbox) via the WC Additional Checkout Fields API.
+* Enhancement - Performance: Optimized Admin JS loading; wcj-admin.js is now scoped strictly to Booster and WooCommerce Order pages.
+* Fix - HPOS Compatibility: Updated Store Exporter and Order Display to use WC CRUD API for custom fields when High-Performance Order Storage is enabled.
+* Fix - Blocks Integration: Implemented a meta bridge to ensure Block-based checkout data is correctly mapped to Booster's legacy format (label-based storage).
+* Fix - HPOS: Removed redundant legacy get_post_meta calls when viewing orders in HPOS mode.
+* WooCommerce 10.6.1 Tested
+* WordPress 6.9.4 Tested
 
 = 7.11.4 - 18/03/2026 =
 * Normalized in-plugin upsell routing so generic compare-first prompts route to /free-vs-elite/ while explicit buy/pricing CTAs stay on /buy-booster/.

--- a/version-details.json
+++ b/version-details.json
@@ -1,9 +1,10 @@
 {
-    "0": "= 7.11.4 - 18/03/2026 =",
-    "1": "* Normalized in-plugin upsell routing so generic compare-first prompts route to /free-vs-elite/ while explicit buy/pricing CTAs stay on /buy-booster/.",
-    "2": "* Kept upgrade-block comparison buttons and other ambiguous/tag-first docs/features/about assists on their current destinations while separating account, support, update, and download routes from generic sales flows.",
-    "3": "* Normalized Booster in-plugin source and UTM tagging across the scoped admin surfaces.",
-    "4": "* Confirmed no direct-checkout plugin CTA was introduced in this release candidate.",
-    "5": "* WooCommerce 10.6.1 Tested",
-    "6": "* WordPress 6.9.1 Tested"
+    "0": "= 7.11.5 - 01/04/2026 =",
+    "1": "* Feature - WooCommerce Blocks: Added support for Checkout Custom Fields (Text, Select, and Checkbox) via the WC Additional Checkout Fields API.",
+    "2": "* Enhancement - Performance: Optimized Admin JS loading; wcj-admin.js is now scoped strictly to Booster and WooCommerce Order pages.",
+    "3": "* Fix - HPOS Compatibility: Updated Store Exporter and Order Display to use WC CRUD API for custom fields when High-Performance Order Storage is enabled.",
+    "4": "* Fix - Blocks Integration: Implemented a meta bridge to ensure Block-based checkout data is correctly mapped to Booster's legacy format (label-based storage).",
+    "5": "* Fix - HPOS: Removed redundant legacy get_post_meta calls when viewing orders in HPOS mode.",
+    "6": "* WooCommerce 10.6.1 Tested",
+    "7": "* WordPress 6.9.4 Tested"
 }

--- a/woocommerce-jetpack.php
+++ b/woocommerce-jetpack.php
@@ -4,7 +4,7 @@
  * Requires Plugins: woocommerce
  * Plugin URI: https://booster.io
  * Description: Supercharge your WooCommerce site with these awesome powerful features.
- * Version: 7.11.4
+ * Version: 7.11.5
  * Author: Pluggabl LLC
  * Author URI: https://booster.io
  * Text Domain: woocommerce-jetpack
@@ -72,7 +72,7 @@ if ( ! class_exists( 'WC_Jetpack' ) ) :
 		 *
 		 * @var string
 		 */
-		public $version = '7.11.4';
+		public $version = '7.11.5';
 
 		/**
 		 * Singleton instance.


### PR DESCRIPTION
= 7.11.5 - 01/04/2026 =
* Feature - WooCommerce Blocks: Added support for Checkout Custom Fields (Text, Select, and Checkbox) via the WC Additional Checkout Fields API.
* Enhancement - Performance: Optimized Admin JS loading; wcj-admin.js is now scoped strictly to Booster and WooCommerce Order pages.
* Fix - HPOS Compatibility: Updated Store Exporter and Order Display to use WC CRUD API for custom fields when High-Performance Order Storage is enabled.
* Fix - Blocks Integration: Implemented a meta bridge to ensure Block-based checkout data is correctly mapped to Booster's legacy format (label-based storage).
* Fix - HPOS: Removed redundant legacy get_post_meta calls when viewing orders in HPOS mode.
* WooCommerce 10.6.1 Tested
* WordPress 6.9.4 Tested