### PR TITLE
8.0.0: Blocks phase 2 + checkout fees Blocks + HPOS cleanup + performance wave 2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,12 +1,12 @@
 == Changelog ==
 
 = 8.0.0 - 15/04/2026 =
-* Feature - WooCommerce Blocks: Checkout Custom Fields phase 2 — visibility conditions (product/category/cart amount), radio-to-select conversion, and section-to-location mapping now work on Blocks checkout.
-* Feature - WooCommerce Blocks: Checkout Fees module now applies simple fees on Blocks checkout via Store API integration.
-* Enhancement - HPOS: Checkout Files Upload module now includes consolidated HPOS helper methods and Store API hook for Blocks-placed orders.
-* Enhancement - Performance: Batch-loaded checkout field options in Blocks integration to eliminate N+1 option queries.
-* Enhancement - Performance: Added request-scope caching for checkout fee configuration to reduce repeated option lookups.
-* Enhancement - Performance: Added cart product/category ID caching in checkout custom fields visibility checks.
+* Feature - WooCommerce Blocks: Checkout Custom Fields — radio fields automatically converted to select dropdowns on Blocks checkout. Batch option loading eliminates N+1 queries during field registration.
+* Feature - WooCommerce Blocks: Checkout Fees module now applies simple fees (fixed and percentage) on Blocks checkout via Store API. Checkout-field-conditional fees remain classic-only.
+* Enhancement - HPOS: Checkout Files Upload module refactored to use consolidated HPOS helper methods in email attachments, order display, and file-to-order paths. Store API hook added for Blocks-placed orders.
+* Enhancement - Performance: Added request-scope caching for checkout fee configuration to reduce repeated option lookups during cart calculation.
+* Enhancement - Performance: Added cart product and category ID caching in checkout custom fields visibility checks, reducing redundant cart iteration on classic checkout.
+* Note - Visibility conditions (product/category/cart-amount show/hide) and placement sections remain classic-checkout-only. WC Blocks API does not support cart-conditional field registration.
 * WooCommerce 10.6.1 Tested
 * WordPress 6.9.4 Tested
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,15 @@
 == Changelog ==
 
+= 8.0.0 - 15/04/2026 =
+* Feature - WooCommerce Blocks: Checkout Custom Fields phase 2 — visibility conditions (product/category/cart amount), radio-to-select conversion, and section-to-location mapping now work on Blocks checkout.
+* Feature - WooCommerce Blocks: Checkout Fees module now applies simple fees on Blocks checkout via Store API integration.
+* Enhancement - HPOS: Checkout Files Upload module now includes consolidated HPOS helper methods and Store API hook for Blocks-placed orders.
+* Enhancement - Performance: Batch-loaded checkout field options in Blocks integration to eliminate N+1 option queries.
+* Enhancement - Performance: Added request-scope caching for checkout fee configuration to reduce repeated option lookups.
+* Enhancement - Performance: Added cart product/category ID caching in checkout custom fields visibility checks.
+* WooCommerce 10.6.1 Tested
+* WordPress 6.9.4 Tested
+
 = 7.11.5 - 01/04/2026 =
 * Feature - WooCommerce Blocks: Added support for Checkout Custom Fields (Text, Select, and Checkbox) via the WC Additional Checkout Fields API.
 * Enhancement - Performance: Optimized Admin JS loading; wcj-admin.js is now scoped strictly to Booster and WooCommerce Order pages.

--- a/includes/class-wcj-checkout-custom-fields-blocks.php
+++ b/includes/class-wcj-checkout-custom-fields-blocks.php
@@ -6,11 +6,17 @@
  * and bridges Blocks-saved data back to Booster meta format so that existing
  * admin display, email, shortcode, and exporter code continues to work.
  *
- * Supported field types on Blocks checkout: text, select, checkbox.
- * Unsupported types (textarea, radio, datepicker, etc.) are silently skipped
- * and continue to work only on classic checkout.
+ * Supported field types on Blocks checkout: text, select, checkbox, radio (as select).
+ * Unsupported types (textarea, datepicker, weekpicker, timepicker, number) are
+ * silently skipped and continue to work only on classic checkout.
  *
- * @version 7.12.0
+ * Visibility conditions (product/category include/exclude, min/max cart amount)
+ * are evaluated server-side during field registration.
+ *
+ * Radio fields are automatically converted to select dropdowns on Blocks checkout
+ * since the WC Blocks API does not support native radio inputs.
+ *
+ * @version 8.0.0
  * @since   7.12.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -25,7 +31,7 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 	/**
 	 * WCJ_Checkout_Custom_Fields_Blocks.
 	 *
-	 * @version 7.12.0
+	 * @version 8.0.0
 	 * @since   7.12.0
 	 */
 	class WCJ_Checkout_Custom_Fields_Blocks {
@@ -46,15 +52,23 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 
 		/**
 		 * Field types supported on WooCommerce Blocks checkout.
+		 * Radio is included and converted to select during registration.
 		 *
 		 * @var array
 		 */
-		private $supported_types = array( 'text', 'select', 'checkbox' );
+		private $supported_types = array( 'text', 'select', 'checkbox', 'radio' );
+
+		/**
+		 * Cached field configuration loaded once during registration.
+		 *
+		 * @var array|null
+		 */
+		private $field_config_cache = null;
 
 		/**
 		 * Constructor.
 		 *
-		 * @version 7.12.0
+		 * @version 8.0.0
 		 * @since   7.12.0
 		 * @param int $total_fields Total number of configured checkout custom fields.
 		 */
@@ -89,22 +103,24 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 		}
 
 		/**
-		 * Register Booster checkout custom fields with the WC Blocks API.
+		 * Load and cache all field configuration in a single pass.
 		 *
-		 * Only registers fields with supported types (text, select, checkbox).
-		 * All fields use the 'order' location so they appear in the
-		 * order/additional-information area of the Checkout block.
+		 * Avoids N+1 option queries by loading all enabled field configs at once.
 		 *
-		 * @version 7.12.0
-		 * @since   7.12.0
+		 * @version 8.0.0
+		 * @since   8.0.0
+		 * @return array Associative array keyed by field index.
 		 */
-		public function register_blocks_checkout_fields() {
-			if ( ! $this->is_blocks_api_available() ) {
-				return;
+		private function get_all_field_configs() {
+			if ( null !== $this->field_config_cache ) {
+				return $this->field_config_cache;
 			}
 
+			$this->field_config_cache = array();
+
 			for ( $i = 1; $i <= $this->total_fields; $i++ ) {
-				if ( 'yes' !== wcj_get_option( 'wcj_checkout_custom_field_enabled_' . $i ) ) {
+				$enabled = wcj_get_option( 'wcj_checkout_custom_field_enabled_' . $i );
+				if ( 'yes' !== $enabled ) {
 					continue;
 				}
 
@@ -113,24 +129,193 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 					continue;
 				}
 
-				$label    = wcj_get_option( 'wcj_checkout_custom_field_label_' . $i, '' );
-				$required = ( 'yes' === wcj_get_option( 'wcj_checkout_custom_field_required_' . $i, 'no' ) );
+				$this->field_config_cache[ $i ] = array(
+					'type'           => $booster_type,
+					'label'          => wcj_get_option( 'wcj_checkout_custom_field_label_' . $i, '' ),
+					'required'       => ( 'yes' === wcj_get_option( 'wcj_checkout_custom_field_required_' . $i, 'no' ) ),
+					'section'        => wcj_get_option( 'wcj_checkout_custom_field_section_' . $i, 'billing' ),
+					'select_options' => wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $i, '' ),
+					'categories_in'  => wcj_get_option( 'wcj_checkout_custom_field_categories_in_' . $i ),
+					'categories_ex'  => wcj_get_option( 'wcj_checkout_custom_field_categories_ex_' . $i ),
+					'products_in'    => wcj_get_option( 'wcj_checkout_custom_field_products_in_' . $i ),
+					'products_ex'    => wcj_get_option( 'wcj_checkout_custom_field_products_ex_' . $i ),
+					'min_cart'       => wcj_get_option( 'wcj_checkout_custom_field_min_cart_amount_' . $i, 0 ),
+					'max_cart'       => wcj_get_option( 'wcj_checkout_custom_field_max_cart_amount_' . $i, 0 ),
+				);
+			}
+
+			return $this->field_config_cache;
+		}
+
+		/**
+		 * Check if a field should be visible based on product/category/cart conditions.
+		 *
+		 * Evaluates the same visibility conditions as classic checkout so that
+		 * Blocks checkout respects show/hide rules for products, categories, and
+		 * cart amount thresholds.
+		 *
+		 * @version 8.0.0
+		 * @since   8.0.0
+		 * @param array $config Field configuration array.
+		 * @return bool
+		 */
+		private function is_field_visible( $config ) {
+			// Cart must be available for visibility checks.
+			if ( ! function_exists( 'WC' ) || null === WC()->cart ) {
+				return true;
+			}
+
+			$cart = WC()->cart;
+
+			// Category exclusion.
+			if ( ! empty( $config['categories_ex'] ) ) {
+				foreach ( $cart->get_cart() as $values ) {
+					$product_categories = get_the_terms( $values['product_id'], 'product_cat' );
+					if ( empty( $product_categories ) ) {
+						continue;
+					}
+					foreach ( $product_categories as $product_category ) {
+						if ( in_array( (string) $product_category->term_id, $config['categories_ex'], true ) ) {
+							return false;
+						}
+					}
+				}
+			}
+
+			// Category inclusion.
+			if ( ! empty( $config['categories_in'] ) ) {
+				$categories_in_cart = array();
+				foreach ( $cart->get_cart() as $values ) {
+					$product_categories = wp_get_post_terms( $values['product_id'], 'product_cat', array( 'fields' => 'ids' ) );
+					$categories_in_cart = array_merge( $product_categories, $categories_in_cart );
+				}
+				if ( count( array_intersect( $config['categories_in'], $categories_in_cart ) ) === 0 ) {
+					return false;
+				}
+			}
+
+			// Product exclusion.
+			if ( ! empty( $config['products_ex'] ) ) {
+				foreach ( $cart->get_cart() as $values ) {
+					if ( in_array( (string) $values['product_id'], $config['products_ex'], true ) ) {
+						return false;
+					}
+				}
+			}
+
+			// Product inclusion.
+			if ( ! empty( $config['products_in'] ) ) {
+				foreach ( $cart->get_cart() as $values ) {
+					if ( in_array( (string) $values['product_id'], $config['products_in'], true ) ) {
+						return true;
+					}
+				}
+				return false;
+			}
+
+			// Min cart amount.
+			$min_cart = (float) $config['min_cart'];
+			if ( $min_cart > 0 ) {
+				$cart->calculate_totals();
+				if ( (float) $cart->total < $min_cart ) {
+					return false;
+				}
+			}
+
+			// Max cart amount.
+			$max_cart = (float) $config['max_cart'];
+			if ( $max_cart > 0 ) {
+				if ( ! $min_cart ) {
+					$cart->calculate_totals();
+				}
+				if ( (float) $cart->total > $max_cart ) {
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		/**
+		 * Map Booster field section to WC Blocks location.
+		 *
+		 * WC Blocks supports 'contact', 'address', and 'order' locations.
+		 * Booster sections are mapped as follows:
+		 *   billing  → address
+		 *   shipping → address
+		 *   account  → contact
+		 *   order    → order (default)
+		 *
+		 * @version 8.0.0
+		 * @since   8.0.0
+		 * @param string $section Booster field section.
+		 * @return string WC Blocks location.
+		 */
+		private function map_section_to_blocks_location( $section ) {
+			switch ( $section ) {
+				case 'billing':
+				case 'shipping':
+					return 'address';
+				case 'account':
+					return 'contact';
+				case 'order':
+				default:
+					return 'order';
+			}
+		}
+
+		/**
+		 * Register Booster checkout custom fields with the WC Blocks API.
+		 *
+		 * Only registers fields with supported types (text, select, checkbox, radio).
+		 * Radio fields are converted to select dropdowns since the Blocks API does
+		 * not support native radio inputs.
+		 *
+		 * Visibility conditions are evaluated before registration so that fields
+		 * hidden by product/category/cart-amount rules are not shown on Blocks.
+		 *
+		 * @version 8.0.0
+		 * @since   7.12.0
+		 */
+		public function register_blocks_checkout_fields() {
+			if ( ! $this->is_blocks_api_available() ) {
+				return;
+			}
+
+			$configs = $this->get_all_field_configs();
+
+			foreach ( $configs as $i => $config ) {
+				// Evaluate visibility conditions.
+				if ( ! $this->is_field_visible( $config ) ) {
+					continue;
+				}
+
+				$blocks_type = $config['type'];
+
+				// Convert radio to select for Blocks (no native radio support).
+				if ( 'radio' === $blocks_type ) {
+					$blocks_type = 'select';
+				}
+
+				$location = $this->map_section_to_blocks_location( $config['section'] );
 
 				$field_args = array(
 					'id'       => $this->get_blocks_field_id( $i ),
-					'label'    => $label,
-					'location' => 'order',
-					'type'     => $booster_type,
-					'required' => $required,
+					'label'    => $config['label'],
+					'location' => $location,
+					'type'     => $blocks_type,
+					'required' => $config['required'],
 				);
 
-				if ( 'select' === $booster_type ) {
-					$options_raw           = wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $i, '' );
+				// Select and radio-as-select both need options.
+				if ( 'select' === $blocks_type ) {
+					$options_raw = $config['select_options'];
+					// For radio fields, options are stored in the same format.
+					if ( 'radio' === $config['type'] ) {
+						$options_raw = wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $i, '' );
+					}
 					$field_args['options'] = $this->format_select_options_for_blocks( $options_raw );
 				}
-
-				// Note: WC Blocks API does not support 'placeholder' for text fields.
-				// Select 'placeholder' is a top-level param but is optional.
 
 				woocommerce_register_additional_checkout_field( $field_args );
 			}
@@ -174,14 +359,30 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 		 * via sanitize_title(). This reverses that mapping so the bridged meta
 		 * stores the same raw label that the classic checkout path would store.
 		 *
-		 * @version 7.12.0
+		 * Works for both select and radio-as-select fields.
+		 *
+		 * @version 8.0.0
 		 * @since   7.12.0
 		 * @param int    $field_index Booster field index.
 		 * @param string $slug        The sanitized slug submitted by Blocks checkout.
 		 * @return string The raw Booster option label, or the slug if no match found.
 		 */
 		private function reverse_map_select_value( $field_index, $slug ) {
-			$options_raw = wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $field_index, '' );
+			$configs = $this->get_all_field_configs();
+			$options_raw = '';
+
+			if ( isset( $configs[ $field_index ] ) ) {
+				$options_raw = $configs[ $field_index ]['select_options'];
+				// For radio fields, fall back to select_options key.
+				if ( 'radio' === $configs[ $field_index ]['type'] && '' === $options_raw ) {
+					$options_raw = wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $field_index, '' );
+				}
+			}
+
+			if ( '' === $options_raw ) {
+				$options_raw = wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $field_index, '' );
+			}
+
 			if ( '' === $options_raw ) {
 				return $slug;
 			}
@@ -228,36 +429,52 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 		 * (_SECTION_wcj_checkout_field_N) so that existing admin order display,
 		 * emails, shortcodes, and store exporters continue to work.
 		 *
-		 * @version 7.12.0
+		 * @version 8.0.0
 		 * @since   7.12.0
 		 * @param \WC_Order $order The order object.
 		 */
 		public function bridge_blocks_meta_to_booster_format( $order ) {
 			$checkout_fields_service = $this->get_checkout_fields_service();
+			$configs                 = $this->get_all_field_configs();
 			$bridged_any             = false;
 
-			for ( $i = 1; $i <= $this->total_fields; $i++ ) {
-				if ( 'yes' !== wcj_get_option( 'wcj_checkout_custom_field_enabled_' . $i ) ) {
-					continue;
-				}
+			foreach ( $configs as $i => $config ) {
+				$booster_type = $config['type'];
+				$blocks_type  = $booster_type;
 
-				$booster_type = wcj_get_option( 'wcj_checkout_custom_field_type_' . $i, 'text' );
-				if ( ! in_array( $booster_type, $this->supported_types, true ) ) {
-					continue;
+				// Radio was registered as select on Blocks.
+				if ( 'radio' === $blocks_type ) {
+					$blocks_type = 'select';
 				}
 
 				$field_id     = $this->get_blocks_field_id( $i );
 				$blocks_value = '';
+				$location     = $this->map_section_to_blocks_location( $config['section'] );
+
+				// Map Blocks location to the service group name.
+				$service_group = 'other';
+				if ( 'address' === $location ) {
+					$service_group = 'address';
+				} elseif ( 'contact' === $location ) {
+					$service_group = 'contact';
+				}
 
 				// Use the WC CheckoutFields service (recommended) to read the value.
 				if ( $checkout_fields_service && method_exists( $checkout_fields_service, 'get_field_from_object' ) ) {
-					$blocks_value = $checkout_fields_service->get_field_from_object( $field_id, $order, 'other' );
+					$blocks_value = $checkout_fields_service->get_field_from_object( $field_id, $order, $service_group );
 				}
 
 				// Fallback: try direct meta read if the service returned empty.
 				if ( '' === $blocks_value || false === $blocks_value || null === $blocks_value ) {
-					$blocks_meta_key = '_wc_other/' . $field_id;
+					$blocks_meta_key = '_wc_' . $service_group . '/' . $field_id;
 					$blocks_value    = $order->get_meta( $blocks_meta_key );
+				}
+
+				// Second fallback: try 'other' group (backward compat with prior version).
+				if ( '' === $blocks_value || false === $blocks_value || null === $blocks_value ) {
+					if ( 'other' !== $service_group ) {
+						$blocks_value = $order->get_meta( '_wc_other/' . $field_id );
+					}
 				}
 
 				// Skip fields with no value (except checkboxes which can be unchecked).
@@ -268,8 +485,8 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 					$blocks_value = '';
 				}
 
-				$section = wcj_get_option( 'wcj_checkout_custom_field_section_' . $i, 'billing' );
-				$label   = wcj_get_option( 'wcj_checkout_custom_field_label_' . $i, '' );
+				$section = $config['section'];
+				$label   = $config['label'];
 
 				$booster_key       = '_' . $section . '_wcj_checkout_field_' . $i;
 				$booster_key_label = '_' . $section . '_wcj_checkout_field_label_' . $i;
@@ -280,8 +497,8 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 					$blocks_value = ( ! empty( $blocks_value ) && 'false' !== $blocks_value && '0' !== $blocks_value ) ? 1 : 0;
 				}
 
-				// Reverse-map select slug back to the raw Booster option label.
-				if ( 'select' === $booster_type ) {
+				// Reverse-map select/radio slug back to the raw Booster option label.
+				if ( in_array( $booster_type, array( 'select', 'radio' ), true ) ) {
 					$blocks_value = $this->reverse_map_select_value( $i, $blocks_value );
 				}
 
@@ -298,10 +515,13 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 					$order->update_meta_data( $checkbox_key, $checkbox_value );
 				}
 
-				// Store select options string for display resolution.
-				if ( 'select' === $booster_type ) {
+				// Store select/radio options string for display resolution.
+				if ( in_array( $booster_type, array( 'select', 'radio' ), true ) ) {
 					$select_key = '_' . $section . '_wcj_checkout_field_select_options_' . $i;
-					$the_values = wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $i, '' );
+					$the_values = $config['select_options'];
+					if ( '' === $the_values ) {
+						$the_values = wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $i, '' );
+					}
 					$order->update_meta_data( $select_key, $the_values );
 				}
 

--- a/includes/class-wcj-checkout-custom-fields-blocks.php
+++ b/includes/class-wcj-checkout-custom-fields-blocks.php
@@ -10,11 +10,17 @@
  * Unsupported types (textarea, datepicker, weekpicker, timepicker, number) are
  * silently skipped and continue to work only on classic checkout.
  *
- * Visibility conditions (product/category include/exclude, min/max cart amount)
- * are evaluated server-side during field registration.
- *
  * Radio fields are automatically converted to select dropdowns on Blocks checkout
  * since the WC Blocks API does not support native radio inputs.
+ *
+ * Note: Visibility conditions (product/category/cart-amount show/hide) are NOT
+ * enforced on Blocks checkout. The WC Blocks additional checkout fields API
+ * registers fields globally at plugin init, before cart context is available.
+ * Visibility conditions continue to work on classic checkout only.
+ *
+ * All fields use the 'order' location (additional-information area) on Blocks.
+ * The WC Blocks 'address' location duplicates fields across both billing and
+ * shipping address groups, which is not the intended Booster section behavior.
  *
  * @version 8.0.0
  * @since   7.12.0
@@ -135,133 +141,10 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 					'required'       => ( 'yes' === wcj_get_option( 'wcj_checkout_custom_field_required_' . $i, 'no' ) ),
 					'section'        => wcj_get_option( 'wcj_checkout_custom_field_section_' . $i, 'billing' ),
 					'select_options' => wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $i, '' ),
-					'categories_in'  => wcj_get_option( 'wcj_checkout_custom_field_categories_in_' . $i ),
-					'categories_ex'  => wcj_get_option( 'wcj_checkout_custom_field_categories_ex_' . $i ),
-					'products_in'    => wcj_get_option( 'wcj_checkout_custom_field_products_in_' . $i ),
-					'products_ex'    => wcj_get_option( 'wcj_checkout_custom_field_products_ex_' . $i ),
-					'min_cart'       => wcj_get_option( 'wcj_checkout_custom_field_min_cart_amount_' . $i, 0 ),
-					'max_cart'       => wcj_get_option( 'wcj_checkout_custom_field_max_cart_amount_' . $i, 0 ),
 				);
 			}
 
 			return $this->field_config_cache;
-		}
-
-		/**
-		 * Check if a field should be visible based on product/category/cart conditions.
-		 *
-		 * Evaluates the same visibility conditions as classic checkout so that
-		 * Blocks checkout respects show/hide rules for products, categories, and
-		 * cart amount thresholds.
-		 *
-		 * @version 8.0.0
-		 * @since   8.0.0
-		 * @param array $config Field configuration array.
-		 * @return bool
-		 */
-		private function is_field_visible( $config ) {
-			// Cart must be available for visibility checks.
-			if ( ! function_exists( 'WC' ) || null === WC()->cart ) {
-				return true;
-			}
-
-			$cart = WC()->cart;
-
-			// Category exclusion.
-			if ( ! empty( $config['categories_ex'] ) ) {
-				foreach ( $cart->get_cart() as $values ) {
-					$product_categories = get_the_terms( $values['product_id'], 'product_cat' );
-					if ( empty( $product_categories ) ) {
-						continue;
-					}
-					foreach ( $product_categories as $product_category ) {
-						if ( in_array( (string) $product_category->term_id, $config['categories_ex'], true ) ) {
-							return false;
-						}
-					}
-				}
-			}
-
-			// Category inclusion.
-			if ( ! empty( $config['categories_in'] ) ) {
-				$categories_in_cart = array();
-				foreach ( $cart->get_cart() as $values ) {
-					$product_categories = wp_get_post_terms( $values['product_id'], 'product_cat', array( 'fields' => 'ids' ) );
-					$categories_in_cart = array_merge( $product_categories, $categories_in_cart );
-				}
-				if ( count( array_intersect( $config['categories_in'], $categories_in_cart ) ) === 0 ) {
-					return false;
-				}
-			}
-
-			// Product exclusion.
-			if ( ! empty( $config['products_ex'] ) ) {
-				foreach ( $cart->get_cart() as $values ) {
-					if ( in_array( (string) $values['product_id'], $config['products_ex'], true ) ) {
-						return false;
-					}
-				}
-			}
-
-			// Product inclusion.
-			if ( ! empty( $config['products_in'] ) ) {
-				foreach ( $cart->get_cart() as $values ) {
-					if ( in_array( (string) $values['product_id'], $config['products_in'], true ) ) {
-						return true;
-					}
-				}
-				return false;
-			}
-
-			// Min cart amount.
-			$min_cart = (float) $config['min_cart'];
-			if ( $min_cart > 0 ) {
-				$cart->calculate_totals();
-				if ( (float) $cart->total < $min_cart ) {
-					return false;
-				}
-			}
-
-			// Max cart amount.
-			$max_cart = (float) $config['max_cart'];
-			if ( $max_cart > 0 ) {
-				if ( ! $min_cart ) {
-					$cart->calculate_totals();
-				}
-				if ( (float) $cart->total > $max_cart ) {
-					return false;
-				}
-			}
-
-			return true;
-		}
-
-		/**
-		 * Map Booster field section to WC Blocks location.
-		 *
-		 * WC Blocks supports 'contact', 'address', and 'order' locations.
-		 * Booster sections are mapped as follows:
-		 *   billing  → address
-		 *   shipping → address
-		 *   account  → contact
-		 *   order    → order (default)
-		 *
-		 * @version 8.0.0
-		 * @since   8.0.0
-		 * @param string $section Booster field section.
-		 * @return string WC Blocks location.
-		 */
-		private function map_section_to_blocks_location( $section ) {
-			switch ( $section ) {
-				case 'billing':
-				case 'shipping':
-					return 'address';
-				case 'account':
-					return 'contact';
-				case 'order':
-				default:
-					return 'order';
-			}
 		}
 
 		/**
@@ -271,8 +154,12 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 		 * Radio fields are converted to select dropdowns since the Blocks API does
 		 * not support native radio inputs.
 		 *
-		 * Visibility conditions are evaluated before registration so that fields
-		 * hidden by product/category/cart-amount rules are not shown on Blocks.
+		 * All fields use the 'order' location so they appear in the
+		 * order/additional-information area of the Checkout block.
+		 *
+		 * Visibility conditions (product/category/cart-amount) are NOT evaluated
+		 * here because the WC Blocks API registers fields at plugin init, before
+		 * cart context is available. Visibility remains classic-checkout-only.
 		 *
 		 * @version 8.0.0
 		 * @since   7.12.0
@@ -285,11 +172,6 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 			$configs = $this->get_all_field_configs();
 
 			foreach ( $configs as $i => $config ) {
-				// Evaluate visibility conditions.
-				if ( ! $this->is_field_visible( $config ) ) {
-					continue;
-				}
-
 				$blocks_type = $config['type'];
 
 				// Convert radio to select for Blocks (no native radio support).
@@ -297,12 +179,10 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 					$blocks_type = 'select';
 				}
 
-				$location = $this->map_section_to_blocks_location( $config['section'] );
-
 				$field_args = array(
 					'id'       => $this->get_blocks_field_id( $i ),
 					'label'    => $config['label'],
-					'location' => $location,
+					'location' => 'order',
 					'type'     => $blocks_type,
 					'required' => $config['required'],
 				);
@@ -368,12 +248,11 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 		 * @return string The raw Booster option label, or the slug if no match found.
 		 */
 		private function reverse_map_select_value( $field_index, $slug ) {
-			$configs = $this->get_all_field_configs();
+			$configs     = $this->get_all_field_configs();
 			$options_raw = '';
 
 			if ( isset( $configs[ $field_index ] ) ) {
 				$options_raw = $configs[ $field_index ]['select_options'];
-				// For radio fields, fall back to select_options key.
 				if ( 'radio' === $configs[ $field_index ]['type'] && '' === $options_raw ) {
 					$options_raw = wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $field_index, '' );
 				}
@@ -440,41 +319,18 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 
 			foreach ( $configs as $i => $config ) {
 				$booster_type = $config['type'];
-				$blocks_type  = $booster_type;
-
-				// Radio was registered as select on Blocks.
-				if ( 'radio' === $blocks_type ) {
-					$blocks_type = 'select';
-				}
 
 				$field_id     = $this->get_blocks_field_id( $i );
 				$blocks_value = '';
-				$location     = $this->map_section_to_blocks_location( $config['section'] );
 
-				// Map Blocks location to the service group name.
-				$service_group = 'other';
-				if ( 'address' === $location ) {
-					$service_group = 'address';
-				} elseif ( 'contact' === $location ) {
-					$service_group = 'contact';
-				}
-
-				// Use the WC CheckoutFields service (recommended) to read the value.
+				// All fields use 'order' location → 'other' service group.
 				if ( $checkout_fields_service && method_exists( $checkout_fields_service, 'get_field_from_object' ) ) {
-					$blocks_value = $checkout_fields_service->get_field_from_object( $field_id, $order, $service_group );
+					$blocks_value = $checkout_fields_service->get_field_from_object( $field_id, $order, 'other' );
 				}
 
 				// Fallback: try direct meta read if the service returned empty.
 				if ( '' === $blocks_value || false === $blocks_value || null === $blocks_value ) {
-					$blocks_meta_key = '_wc_' . $service_group . '/' . $field_id;
-					$blocks_value    = $order->get_meta( $blocks_meta_key );
-				}
-
-				// Second fallback: try 'other' group (backward compat with prior version).
-				if ( '' === $blocks_value || false === $blocks_value || null === $blocks_value ) {
-					if ( 'other' !== $service_group ) {
-						$blocks_value = $order->get_meta( '_wc_other/' . $field_id );
-					}
+					$blocks_value = $order->get_meta( '_wc_other/' . $field_id );
 				}
 
 				// Skip fields with no value (except checkboxes which can be unchecked).
@@ -492,7 +348,7 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 				$booster_key_label = '_' . $section . '_wcj_checkout_field_label_' . $i;
 				$booster_key_type  = '_' . $section . '_wcj_checkout_field_type_' . $i;
 
-				// Normalize checkbox values: WC Blocks stores "true"/"false" or "1"/"0", Booster stores 1/0.
+				// Normalize checkbox values.
 				if ( 'checkbox' === $booster_type ) {
 					$blocks_value = ( ! empty( $blocks_value ) && 'false' !== $blocks_value && '0' !== $blocks_value ) ? 1 : 0;
 				}

--- a/includes/class-wcj-checkout-custom-fields.php
+++ b/includes/class-wcj-checkout-custom-fields.php
@@ -812,29 +812,22 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields' ) ) :
 				return true;
 			}
 
+			// Use cached cart data to avoid re-iterating cart for each field.
+			$cart_product_ids  = $this->get_cart_product_ids();
+			$cart_category_ids = $this->get_cart_category_ids();
+
 			// Checking categories.
 			$categories_ex = wcj_get_option( 'wcj_checkout_custom_field_categories_ex_' . $i );
 			if ( ! empty( $categories_ex ) ) {
-				foreach ( WC()->cart->get_cart() as $cart_item_key => $values ) {
-					$product_categories = get_the_terms( $values['product_id'], 'product_cat' );
-					if ( empty( $product_categories ) ) {
-						continue;
-					}
-					foreach ( $product_categories as $product_category ) {
-						if ( in_array( (string) $product_category->term_id, $categories_ex, true ) ) {
-							return false;
-						}
+				foreach ( $cart_category_ids as $cat_id ) {
+					if ( in_array( (string) $cat_id, $categories_ex, true ) ) {
+						return false;
 					}
 				}
 			}
 			$categories_in = wcj_get_option( 'wcj_checkout_custom_field_categories_in_' . $i );
 			if ( ! empty( $categories_in ) ) {
-				$categories_in_cart = array();
-				foreach ( WC()->cart->get_cart() as $cart_item_key => $values ) {
-					$product_categories = wp_get_post_terms( $values['product_id'], 'product_cat', array( 'fields' => 'ids' ) );
-					$categories_in_cart = array_merge( $product_categories, $categories_in_cart );
-				}
-				if ( count( array_intersect( $categories_in, $categories_in_cart ) ) === 0 ) {
+				if ( count( array_intersect( $categories_in, array_map( 'strval', $cart_category_ids ) ) ) === 0 ) {
 					return false;
 				}
 			}
@@ -842,16 +835,16 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields' ) ) :
 			// Checking products.
 			$products_ex = wcj_get_option( 'wcj_checkout_custom_field_products_ex_' . $i );
 			if ( ! empty( $products_ex ) ) {
-				foreach ( WC()->cart->get_cart() as $cart_item_key => $values ) {
-					if ( in_array( (string) $values['product_id'], $products_ex, true ) ) {
+				foreach ( $cart_product_ids as $product_id ) {
+					if ( in_array( $product_id, $products_ex, true ) ) {
 						return false;
 					}
 				}
 			}
 			$products_in = wcj_get_option( 'wcj_checkout_custom_field_products_in_' . $i );
 			if ( ! empty( $products_in ) ) {
-				foreach ( WC()->cart->get_cart() as $cart_item_key => $values ) {
-					if ( in_array( (string) $values['product_id'], $products_in, true ) ) {
+				foreach ( $cart_product_ids as $product_id ) {
+					if ( in_array( $product_id, $products_in, true ) ) {
 						return true;
 					}
 				}

--- a/includes/class-wcj-checkout-custom-fields.php
+++ b/includes/class-wcj-checkout-custom-fields.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Checkout Custom Fields
  *
- * @version 7.1.8
+ * @version 8.0.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
  */
@@ -16,7 +16,7 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields' ) ) :
 	/**
 	 * WCJ_Checkout_Custom_Fields.
 	 *
-	 * @version 7.1.6
+	 * @version 8.0.0
 	 */
 	class WCJ_Checkout_Custom_Fields extends WCJ_Module {
 
@@ -26,6 +26,20 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields' ) ) :
 		 * @var varchar $wcj_checkout_custom_fields_total_number Module.
 		 */
 		public $wcj_checkout_custom_fields_total_number;
+
+		/**
+		 * Request-scope cache for cart product IDs to avoid repeated cart iteration.
+		 *
+		 * @var array|null
+		 */
+		private $cart_product_ids_cache = null;
+
+		/**
+		 * Request-scope cache for cart category IDs to avoid repeated term queries.
+		 *
+		 * @var array|null
+		 */
+		private $cart_category_ids_cache = null;
 		/**
 		 * Constructor.
 		 *
@@ -741,9 +755,52 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields' ) ) :
 		}
 
 		/**
+		 * Get cached cart product IDs to avoid repeated cart iteration.
+		 *
+		 * @version 8.0.0
+		 * @since   8.0.0
+		 * @return array
+		 */
+		private function get_cart_product_ids() {
+			if ( null !== $this->cart_product_ids_cache ) {
+				return $this->cart_product_ids_cache;
+			}
+			$this->cart_product_ids_cache = array();
+			if ( function_exists( 'WC' ) && null !== WC()->cart ) {
+				foreach ( WC()->cart->get_cart() as $values ) {
+					$this->cart_product_ids_cache[] = (string) $values['product_id'];
+				}
+			}
+			return $this->cart_product_ids_cache;
+		}
+
+		/**
+		 * Get cached cart category IDs to avoid repeated term queries.
+		 *
+		 * @version 8.0.0
+		 * @since   8.0.0
+		 * @return array
+		 */
+		private function get_cart_category_ids() {
+			if ( null !== $this->cart_category_ids_cache ) {
+				return $this->cart_category_ids_cache;
+			}
+			$this->cart_category_ids_cache = array();
+			$product_ids                   = $this->get_cart_product_ids();
+			foreach ( $product_ids as $product_id ) {
+				$categories = wp_get_post_terms( (int) $product_id, 'product_cat', array( 'fields' => 'ids' ) );
+				if ( ! is_wp_error( $categories ) ) {
+					$this->cart_category_ids_cache = array_merge( $this->cart_category_ids_cache, $categories );
+				}
+			}
+			$this->cart_category_ids_cache = array_unique( $this->cart_category_ids_cache );
+			return $this->cart_category_ids_cache;
+		}
+
+		/**
 		 * Is_visible.
 		 *
-		 * @version 5.6.2
+		 * @version 8.0.0
 		 * @since   2.6.0
 		 * @todo    add "user roles to include/exclude"
 		 * @param string $i defines the i.

--- a/includes/class-wcj-checkout-fees.php
+++ b/includes/class-wcj-checkout-fees.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Checkout Fees
  *
- * @version 7.1.6
+ * @version 8.0.0
  * @since   3.7.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -14,9 +14,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 	/**
-	 * WCJ_Checkout_Customization.
+	 * WCJ_Checkout_Fees.
 	 *
-	 * @version 7.1.6
+	 * @version 8.0.0
 	 */
 	class WCJ_Checkout_Fees extends WCJ_Module {
 
@@ -28,11 +28,17 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 		public $checkout_fields;
 
 		/**
+		 * Cached fee configuration to avoid repeated option lookups.
+		 *
+		 * @var array|null
+		 */
+		private $cached_fees_config = null;
+
+		/**
 		 * Constructor.
 		 *
-		 * @version 5.6.7
+		 * @version 8.0.0
 		 * @since   3.7.0
-		 * @todo    (maybe) rename module to "Cart & Checkout Fees"
 		 */
 		public function __construct() {
 
@@ -44,7 +50,7 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 			parent::__construct();
 
 			if ( $this->is_enabled() ) {
-				// Core function.
+				// Core function — fires on both classic and Blocks checkout.
 				add_action( 'woocommerce_review_order_after_submit', array( $this, 'wcj_add_nonce_checkout_fees' ), PHP_INT_MAX );
 				add_action( 'woocommerce_cart_calculate_fees', array( $this, 'add_fees' ), PHP_INT_MAX );
 				// Checkout fields.
@@ -54,6 +60,21 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 					add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 				}
 			}
+		}
+
+		/**
+		 * Check if the current request is a WC Store API request (Blocks checkout).
+		 *
+		 * @version 8.0.0
+		 * @since   8.0.0
+		 * @return bool
+		 */
+		private function is_store_api_request() {
+			if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
+				return false;
+			}
+			$uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+			return false !== strpos( $uri, '/wc/store/' );
 		}
 
 		/**
@@ -78,7 +99,7 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 		/**
 		 * Validate fee without considering overlapping.
 		 *
-		 * @version 5.6.7
+		 * @version 8.0.0
 		 * @since   4.5.0
 		 *
 		 * @param int                    $fee_id  defines the fee_id.
@@ -88,8 +109,8 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 		 */
 		public function is_fee_valid( $fee_id, \WC_Cart $cart ) {
 			$fees    = $this->get_fees();
-			$enabled = wcj_get_option( 'wcj_checkout_fees_data_enabled', array() );
-			$values  = wcj_get_option( 'wcj_checkout_fees_data_values', array() );
+			$enabled = $this->get_fee_option( 'wcj_checkout_fees_data_enabled' );
+			$values  = $this->get_fee_option( 'wcj_checkout_fees_data_values' );
 
 			// Check if is active and empty value.
 			$value = ( isset( $values[ $fee_id ] ) ? $values[ $fee_id ] : 0 );
@@ -116,8 +137,13 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 				return false;
 			}
 
-			// Check checkout fields.
+			// Check checkout fields — only works on classic checkout (POST data).
+			// On Blocks checkout (Store API), checkout-field-conditional fees are skipped.
 			if ( ! empty( $this->checkout_fields[ $fee_id ] ) ) {
+				if ( $this->is_store_api_request() ) {
+					// Checkout-field-conditional fees are not supported on Blocks checkout.
+					return false;
+				}
 				if ( isset( $post_data ) || isset( $_REQUEST['post_data'] ) ) {
 					if ( ! isset( $post_data ) ) {
 						$post_data = array();
@@ -156,30 +182,51 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 		}
 
 		/**
+		 * Get a fee-related option with request-scope caching.
+		 *
+		 * Avoids repeated identical wcj_get_option calls within the same request
+		 * for fee configuration arrays.
+		 *
+		 * @version 8.0.0
+		 * @since   8.0.0
+		 * @param string $option_name The option key.
+		 * @return mixed
+		 */
+		private function get_fee_option( $option_name ) {
+			if ( null === $this->cached_fees_config ) {
+				$this->cached_fees_config = array();
+			}
+			if ( ! isset( $this->cached_fees_config[ $option_name ] ) ) {
+				$this->cached_fees_config[ $option_name ] = wcj_get_option( $option_name, array() );
+			}
+			return $this->cached_fees_config[ $option_name ];
+		}
+
+		/**
 		 * Get Fees.
 		 *
-		 * @version 4.6.1
+		 * @version 8.0.0
 		 * @since   4.5.0
 		 *
-		 * @param bool $only_enabled check enalbed.
+		 * @param bool $only_enabled check enabled.
 		 * @param bool $adjust_priority check adjust_priority.
 		 *
 		 * @return array
 		 */
 		public function get_fees( $only_enabled = true, $adjust_priority = true ) {
 			$total_number    = apply_filters( 'booster_option', 1, wcj_get_option( 'wcj_checkout_fees_total_number', 1 ) );
-			$titles          = wcj_get_option( 'wcj_checkout_fees_data_titles', array() );
-			$types           = wcj_get_option( 'wcj_checkout_fees_data_types', array() );
-			$values          = wcj_get_option( 'wcj_checkout_fees_data_values', array() );
-			$cart_min        = wcj_get_option( 'wcj_checkout_fees_cart_min_amount', array() );
-			$cart_min_total  = wcj_get_option( 'wcj_checkout_fees_cart_min_total_amount', array() );
-			$cart_max        = wcj_get_option( 'wcj_checkout_fees_cart_max_amount', array() );
-			$cart_max_total  = wcj_get_option( 'wcj_checkout_fees_cart_max_total_amount', array() );
-			$taxable         = wcj_get_option( 'wcj_checkout_fees_data_taxable', array() );
-			$checkout_fields = wcj_get_option( 'wcj_checkout_fees_data_values', array() );
-			$enabled         = wcj_get_option( 'wcj_checkout_fees_data_enabled', array() );
-			$overlap_opt     = wcj_get_option( 'wcj_checkout_fees_overlap', array() );
-			$priorities      = wcj_get_option( 'wcj_checkout_fees_priority', array() );
+			$titles          = $this->get_fee_option( 'wcj_checkout_fees_data_titles' );
+			$types           = $this->get_fee_option( 'wcj_checkout_fees_data_types' );
+			$values          = $this->get_fee_option( 'wcj_checkout_fees_data_values' );
+			$cart_min        = $this->get_fee_option( 'wcj_checkout_fees_cart_min_amount' );
+			$cart_min_total  = $this->get_fee_option( 'wcj_checkout_fees_cart_min_total_amount' );
+			$cart_max        = $this->get_fee_option( 'wcj_checkout_fees_cart_max_amount' );
+			$cart_max_total  = $this->get_fee_option( 'wcj_checkout_fees_cart_max_total_amount' );
+			$taxable         = $this->get_fee_option( 'wcj_checkout_fees_data_taxable' );
+			$checkout_fields = $this->get_fee_option( 'wcj_checkout_fees_data_values' );
+			$enabled         = $this->get_fee_option( 'wcj_checkout_fees_data_enabled' );
+			$overlap_opt     = $this->get_fee_option( 'wcj_checkout_fees_overlap' );
+			$priorities      = $this->get_fee_option( 'wcj_checkout_fees_priority' );
 
 			$fees = array();
 			for ( $i = 1; $i <= $total_number; $i ++ ) {
@@ -219,7 +266,7 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 		/**
 		 * Get valid fees.
 		 *
-		 * @version 4.5.0
+		 * @version 8.0.0
 		 * @since   4.5.0
 		 *
 		 * @param string | array $cart define cart details.
@@ -228,10 +275,10 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 		 * @return array
 		 */
 		public function get_valid_fees( $cart, $ignore_overlapped = true ) {
-			$titles  = wcj_get_option( 'wcj_checkout_fees_data_titles', array() );
-			$types   = wcj_get_option( 'wcj_checkout_fees_data_types', array() );
-			$values  = wcj_get_option( 'wcj_checkout_fees_data_values', array() );
-			$taxable = wcj_get_option( 'wcj_checkout_fees_data_taxable', array() );
+			$titles  = $this->get_fee_option( 'wcj_checkout_fees_data_titles' );
+			$types   = $this->get_fee_option( 'wcj_checkout_fees_data_types' );
+			$values  = $this->get_fee_option( 'wcj_checkout_fees_data_values' );
+			$taxable = $this->get_fee_option( 'wcj_checkout_fees_data_taxable' );
 
 			$fees = $this->get_fees();
 
@@ -273,21 +320,16 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 		/**
 		 * Add_fees.
 		 *
-		 * @version 4.5.0
+		 * Fires on both classic checkout and WooCommerce Blocks checkout (via Store API).
+		 * Simple fees (without checkout field conditions) work on both.
+		 * Checkout-field-conditional fees only work on classic checkout.
+		 *
+		 * @version 8.0.0
 		 * @since   3.7.0
-		 * @todo    fees with same title
-		 * @todo    options: `tax_class`
-		 * @todo    options: `cart total` (for percent) - include/exclude shipping etc. - https://docs.woocommerce.com/wc-apidocs/class-WC_Cart.html
-		 * @todo    options: `rounding` (for percent)
-		 * @todo    options: `min/max cart amount`
-		 * @todo    options: `products, cats, tags to include/exclude`
-		 * @todo    options: `countries to include/exclude`
-		 * @todo    options: `user roles to include/exclude`
-		 * @todo    see https://wcbooster.zendesk.com/agent/tickets/446
 		 * @param string | array $cart defines the cart.
 		 */
 		public function add_fees( $cart ) {
-			if ( ! wcj_is_frontend() ) {
+			if ( ! wcj_is_frontend() && ! $this->is_store_api_request() ) {
 				return;
 			}
 

--- a/includes/class-wcj-checkout-files-upload.php
+++ b/includes/class-wcj-checkout-files-upload.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Checkout Files Upload
  *
- * @version 7.2.5
+ * @version 8.0.0
  * @since   2.4.5
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -14,12 +14,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 	/**
-	 * WCJ_Checkout_Customization.
+	 * WCJ_Checkout_Files_Upload.
 	 *
-	 * @version 7.1.6
+	 * @version 8.0.0
 	 */
 	class WCJ_Checkout_Files_Upload extends WCJ_Module {
-
 
 		/**
 		 * The module checkout_files_upload_notice_type
@@ -76,6 +75,8 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 					}
 				}
 				add_action( 'woocommerce_checkout_order_processed', array( $this, 'add_files_to_order' ), PHP_INT_MAX, 2 );
+				// Handle file-to-order copy for Blocks checkout (Store API).
+				add_action( 'woocommerce_store_api_checkout_order_processed', array( $this, 'add_files_to_order_from_blocks' ) );
 				add_action( 'woocommerce_after_checkout_validation', array( $this, 'validate_on_checkout' ) );
 				add_action( 'woocommerce_order_details_after_order_table', array( $this, 'add_files_to_order_display' ), PHP_INT_MAX );
 				add_action( 'woocommerce_email_after_order_table', array( $this, 'add_files_to_order_display' ), PHP_INT_MAX );
@@ -118,6 +119,105 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 				)
 			);
 			$this->checkout_files_upload_notice_type = wcj_get_option( 'wcj_checkout_files_upload_notice_type', 'wc_add_notice' );
+		}
+
+		/**
+		 * Get order meta with HPOS compatibility.
+		 *
+		 * Consolidates the repeated if/else HPOS pattern into a single method.
+		 *
+		 * @version 8.0.0
+		 * @since   8.0.0
+		 * @param int|WC_Order $order_or_id Order object or order ID.
+		 * @param string       $meta_key    Meta key to retrieve.
+		 * @return mixed
+		 */
+		private function get_order_file_meta( $order_or_id, $meta_key ) {
+			if ( true === wcj_is_hpos_enabled() ) {
+				$order = is_numeric( $order_or_id ) ? wcj_get_order( $order_or_id ) : $order_or_id;
+				if ( $order && false !== $order ) {
+					return $order->get_meta( $meta_key );
+				}
+				return '';
+			}
+			$order_id = is_numeric( $order_or_id ) ? $order_or_id : wcj_get_order_id( $order_or_id );
+			return get_post_meta( $order_id, $meta_key, true );
+		}
+
+		/**
+		 * Update order meta with HPOS compatibility.
+		 *
+		 * @version 8.0.0
+		 * @since   8.0.0
+		 * @param int|WC_Order $order_or_id Order object or order ID.
+		 * @param string       $meta_key    Meta key to update.
+		 * @param mixed        $meta_value  Meta value.
+		 */
+		private function update_order_file_meta( $order_or_id, $meta_key, $meta_value ) {
+			if ( true === wcj_is_hpos_enabled() ) {
+				$order = is_numeric( $order_or_id ) ? wcj_get_order( $order_or_id ) : $order_or_id;
+				if ( $order && false !== $order ) {
+					$order->update_meta_data( $meta_key, $meta_value );
+				}
+			} else {
+				$order_id = is_numeric( $order_or_id ) ? $order_or_id : wcj_get_order_id( $order_or_id );
+				update_post_meta( $order_id, $meta_key, $meta_value );
+			}
+		}
+
+		/**
+		 * Delete order meta with HPOS compatibility.
+		 *
+		 * @version 8.0.0
+		 * @since   8.0.0
+		 * @param int|WC_Order $order_or_id Order object or order ID.
+		 * @param string       $meta_key    Meta key to delete.
+		 */
+		private function delete_order_file_meta( $order_or_id, $meta_key ) {
+			if ( true === wcj_is_hpos_enabled() ) {
+				$order = is_numeric( $order_or_id ) ? wcj_get_order( $order_or_id ) : $order_or_id;
+				if ( $order && false !== $order ) {
+					$order->delete_meta_data( $meta_key );
+				}
+			} else {
+				$order_id = is_numeric( $order_or_id ) ? $order_or_id : wcj_get_order_id( $order_or_id );
+				delete_post_meta( $order_id, $meta_key );
+			}
+		}
+
+		/**
+		 * Save order after HPOS meta operations if needed.
+		 *
+		 * @version 8.0.0
+		 * @since   8.0.0
+		 * @param int|WC_Order $order_or_id Order object or order ID.
+		 */
+		private function save_order_if_hpos( $order_or_id ) {
+			if ( true === wcj_is_hpos_enabled() ) {
+				$order = is_numeric( $order_or_id ) ? wcj_get_order( $order_or_id ) : $order_or_id;
+				if ( $order && false !== $order ) {
+					$order->save();
+				}
+			}
+		}
+
+		/**
+		 * Handle file-to-order copy for Blocks checkout (Store API).
+		 *
+		 * This is the Blocks-checkout equivalent of add_files_to_order().
+		 * Called via woocommerce_store_api_checkout_order_processed which receives
+		 * the WC_Order object directly.
+		 *
+		 * @version 8.0.0
+		 * @since   8.0.0
+		 * @param \WC_Order $order The order object.
+		 */
+		public function add_files_to_order_from_blocks( $order ) {
+			if ( ! $order || false === $order ) {
+				return;
+			}
+			$order_id = $order->get_id();
+			$this->add_files_to_order( $order_id, null );
 		}
 
 		/**

--- a/includes/class-wcj-checkout-files-upload.php
+++ b/includes/class-wcj-checkout-files-upload.php
@@ -296,7 +296,7 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 		/**
 		 * Add_files_to_email_attachments.
 		 *
-		 * @version 7.1.4
+		 * @version 8.0.0
 		 * @since   2.5.5
 		 * @param array         $attachments defines the attachments.
 		 * @param bool | string $status defines the status.
@@ -307,16 +307,9 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 				( 'new_order' === $status && 'yes' === wcj_get_option( 'wcj_checkout_files_upload_attach_to_admin_new_order', 'yes' ) ) ||
 				( 'customer_processing_order' === $status && 'yes' === wcj_get_option( 'wcj_checkout_files_upload_attach_to_customer_processing_order', 'yes' ) )
 			) {
-				if ( true === wcj_is_hpos_enabled() ) {
-					$total_files = $order->get_meta( '_wcj_checkout_files_total_files' );
-					for ( $i = 1; $i <= $total_files; $i++ ) {
-						$attachments[] = wcj_get_wcj_uploads_dir( 'checkout_files_upload' ) . '/' . $order->get_meta( '_wcj_checkout_files_upload_' . $i );
-					}
-				} else {
-					$total_files = get_post_meta( wcj_get_order_id( $order ), '_wcj_checkout_files_total_files', true );
-					for ( $i = 1; $i <= $total_files; $i++ ) {
-						$attachments[] = wcj_get_wcj_uploads_dir( 'checkout_files_upload' ) . '/' . get_post_meta( wcj_get_order_id( $order ), '_wcj_checkout_files_upload_' . $i, true );
-					}
+				$total_files = $this->get_order_file_meta( $order, '_wcj_checkout_files_total_files' );
+				for ( $i = 1; $i <= $total_files; $i++ ) {
+					$attachments[] = wcj_get_wcj_uploads_dir( 'checkout_files_upload' ) . '/' . $this->get_order_file_meta( $order, '_wcj_checkout_files_upload_' . $i );
 				}
 			}
 			return $attachments;
@@ -331,14 +324,10 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 		 * @param string | int $order defines the order.
 		 */
 		public function add_files_to_order_display( $order ) {
-			$order_id = wcj_get_order_id( $order );
-			$html     = '';
-			if ( true === wcj_is_hpos_enabled() ) {
-				$total_files = $order->get_meta( '_wcj_checkout_files_total_files' );
-			} else {
-				$total_files = get_post_meta( $order_id, '_wcj_checkout_files_total_files', true );
-			}
-			$do_add_img = false;
+			$order_id    = wcj_get_order_id( $order );
+			$html        = '';
+			$total_files = $this->get_order_file_meta( $order, '_wcj_checkout_files_total_files' );
+			$do_add_img  = false;
 			if ( 'woocommerce_email_after_order_table' === current_filter() ) {
 				$template_before = $this->templates_settings['email_before'];
 				$template_after  = $this->templates_settings['email_after'];
@@ -353,19 +342,11 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 				}
 			}
 			for ( $i = 1; $i <= $total_files; $i++ ) {
-				if ( true === wcj_is_hpos_enabled() ) {
-					$real_file_name = $order->get_meta( '_wcj_checkout_files_upload_real_name_' . $i );
-				} else {
-					$real_file_name = get_post_meta( $order_id, '_wcj_checkout_files_upload_real_name_' . $i, true );
-				}
+				$real_file_name = $this->get_order_file_meta( $order, '_wcj_checkout_files_upload_real_name_' . $i );
 				if ( '' !== $real_file_name ) {
 					$img = '';
 					if ( $do_add_img ) {
-						if ( true === wcj_is_hpos_enabled() ) {
-							$order_file_name = wcj_get_wcj_uploads_dir( 'checkout_files_upload' ) . '/' . $order->get_meta( '_wcj_checkout_files_upload_' . $i );
-						} else {
-							$order_file_name = wcj_get_wcj_uploads_dir( 'checkout_files_upload' ) . '/' . get_post_meta( $order_id, '_wcj_checkout_files_upload_' . $i, true );
-						}
+						$order_file_name = wcj_get_wcj_uploads_dir( 'checkout_files_upload' ) . '/' . $this->get_order_file_meta( $order, '_wcj_checkout_files_upload_' . $i );
 						if ( is_array( getimagesize( $order_file_name ) ) ) {
 							$link = esc_url(
 								add_query_arg(
@@ -661,21 +642,12 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 					}
 					wp_delete_file( $tmp_file_name );
 					wcj_session_set( 'wcj_checkout_files_upload_' . $i, null );
-					if ( true === wcj_is_hpos_enabled() && $order && false !== $order ) {
-						$order->update_meta_data( '_wcj_checkout_files_upload_' . $i, $download_file_name );
-						$order->update_meta_data( '_wcj_checkout_files_upload_real_name_' . $i, $file_name );
-					} else {
-						update_post_meta( $order_id, '_wcj_checkout_files_upload_' . $i, $download_file_name );
-						update_post_meta( $order_id, '_wcj_checkout_files_upload_real_name_' . $i, $file_name );
-					}
+					$this->update_order_file_meta( $order, '_wcj_checkout_files_upload_' . $i, $download_file_name );
+					$this->update_order_file_meta( $order, '_wcj_checkout_files_upload_real_name_' . $i, $file_name );
 				}
 			}
-			if ( true === wcj_is_hpos_enabled() && $order && false !== $order ) {
-				$order->update_meta_data( '_wcj_checkout_files_total_files', $total_number );
-				$order->save();
-			} else {
-				update_post_meta( $order_id, '_wcj_checkout_files_total_files', $total_number );
-			}
+			$this->update_order_file_meta( $order, '_wcj_checkout_files_total_files', $total_number );
+			$this->save_order_if_hpos( $order );
 		}
 
 		/**

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: woocommerce, abandoned cart, cart recovery, swatches, woocommerce pdf invo
 Requires at least: 5.8
 Tested up to: 6.9.4
 Requires PHP: 7.2
-Stable tag: 7.11.5
+Stable tag: 8.0.0
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -346,6 +346,16 @@ No. Onboarding analytics are local-only (apply/undo/mode views) to improve the e
 * For support please visit the [Plugin Support Forum](https://wordpress.org/support/plugin/woocommerce-jetpack/).
 
 == Changelog ==
+
+= 8.0.0 - 15/04/2026 =
+* Feature - WooCommerce Blocks: Checkout Custom Fields phase 2 — visibility conditions (product/category/cart amount), radio-to-select conversion, and section-to-location mapping now work on Blocks checkout.
+* Feature - WooCommerce Blocks: Checkout Fees module now applies simple fees on Blocks checkout via Store API integration.
+* Enhancement - HPOS: Checkout Files Upload module now includes consolidated HPOS helper methods and Store API hook for Blocks-placed orders.
+* Enhancement - Performance: Batch-loaded checkout field options in Blocks integration to eliminate N+1 option queries.
+* Enhancement - Performance: Added request-scope caching for checkout fee configuration to reduce repeated option lookups.
+* Enhancement - Performance: Added cart product/category ID caching in checkout custom fields visibility checks.
+* WooCommerce 10.6.1 Tested
+* WordPress 6.9.4 Tested
 
 = 7.11.5 - 01/04/2026 =
 * Feature - WooCommerce Blocks: Added support for Checkout Custom Fields (Text, Select, and Checkbox) via the WC Additional Checkout Fields API.

--- a/readme.txt
+++ b/readme.txt
@@ -348,12 +348,12 @@ No. Onboarding analytics are local-only (apply/undo/mode views) to improve the e
 == Changelog ==
 
 = 8.0.0 - 15/04/2026 =
-* Feature - WooCommerce Blocks: Checkout Custom Fields phase 2 — visibility conditions (product/category/cart amount), radio-to-select conversion, and section-to-location mapping now work on Blocks checkout.
-* Feature - WooCommerce Blocks: Checkout Fees module now applies simple fees on Blocks checkout via Store API integration.
-* Enhancement - HPOS: Checkout Files Upload module now includes consolidated HPOS helper methods and Store API hook for Blocks-placed orders.
-* Enhancement - Performance: Batch-loaded checkout field options in Blocks integration to eliminate N+1 option queries.
-* Enhancement - Performance: Added request-scope caching for checkout fee configuration to reduce repeated option lookups.
-* Enhancement - Performance: Added cart product/category ID caching in checkout custom fields visibility checks.
+* Feature - WooCommerce Blocks: Checkout Custom Fields — radio fields automatically converted to select dropdowns on Blocks checkout. Batch option loading eliminates N+1 queries during field registration.
+* Feature - WooCommerce Blocks: Checkout Fees module now applies simple fees (fixed and percentage) on Blocks checkout via Store API. Checkout-field-conditional fees remain classic-only.
+* Enhancement - HPOS: Checkout Files Upload module refactored to use consolidated HPOS helper methods in email attachments, order display, and file-to-order paths. Store API hook added for Blocks-placed orders.
+* Enhancement - Performance: Added request-scope caching for checkout fee configuration to reduce repeated option lookups during cart calculation.
+* Enhancement - Performance: Added cart product and category ID caching in checkout custom fields visibility checks, reducing redundant cart iteration on classic checkout.
+* Note - Visibility conditions (product/category/cart-amount show/hide) and placement sections remain classic-checkout-only. WC Blocks API does not support cart-conditional field registration.
 * WooCommerce 10.6.1 Tested
 * WordPress 6.9.4 Tested
 

--- a/version-details.json
+++ b/version-details.json
@@ -1,10 +1,11 @@
 {
-    "0": "= 7.11.5 - 01/04/2026 =",
-    "1": "* Feature - WooCommerce Blocks: Added support for Checkout Custom Fields (Text, Select, and Checkbox) via the WC Additional Checkout Fields API.",
-    "2": "* Enhancement - Performance: Optimized Admin JS loading; wcj-admin.js is now scoped strictly to Booster and WooCommerce Order pages.",
-    "3": "* Fix - HPOS Compatibility: Updated Store Exporter and Order Display to use WC CRUD API for custom fields when High-Performance Order Storage is enabled.",
-    "4": "* Fix - Blocks Integration: Implemented a meta bridge to ensure Block-based checkout data is correctly mapped to Booster's legacy format (label-based storage).",
-    "5": "* Fix - HPOS: Removed redundant legacy get_post_meta calls when viewing orders in HPOS mode.",
-    "6": "* WooCommerce 10.6.1 Tested",
-    "7": "* WordPress 6.9.4 Tested"
+    "0": "= 8.0.0 - 15/04/2026 =",
+    "1": "* Feature - WooCommerce Blocks: Checkout Custom Fields phase 2 — visibility conditions (product/category/cart amount), radio-to-select conversion, and section-to-location mapping now work on Blocks checkout.",
+    "2": "* Feature - WooCommerce Blocks: Checkout Fees module now applies simple fees on Blocks checkout via Store API integration.",
+    "3": "* Enhancement - HPOS: Checkout Files Upload module now includes consolidated HPOS helper methods and Store API hook for Blocks-placed orders.",
+    "4": "* Enhancement - Performance: Batch-loaded checkout field options in Blocks integration to eliminate N+1 option queries.",
+    "5": "* Enhancement - Performance: Added request-scope caching for checkout fee configuration to reduce repeated option lookups.",
+    "6": "* Enhancement - Performance: Added cart product/category ID caching in checkout custom fields visibility checks.",
+    "7": "* WooCommerce 10.6.1 Tested",
+    "8": "* WordPress 6.9.4 Tested"
 }

--- a/version-details.json
+++ b/version-details.json
@@ -1,11 +1,11 @@
 {
     "0": "= 8.0.0 - 15/04/2026 =",
-    "1": "* Feature - WooCommerce Blocks: Checkout Custom Fields phase 2 — visibility conditions (product/category/cart amount), radio-to-select conversion, and section-to-location mapping now work on Blocks checkout.",
-    "2": "* Feature - WooCommerce Blocks: Checkout Fees module now applies simple fees on Blocks checkout via Store API integration.",
-    "3": "* Enhancement - HPOS: Checkout Files Upload module now includes consolidated HPOS helper methods and Store API hook for Blocks-placed orders.",
-    "4": "* Enhancement - Performance: Batch-loaded checkout field options in Blocks integration to eliminate N+1 option queries.",
-    "5": "* Enhancement - Performance: Added request-scope caching for checkout fee configuration to reduce repeated option lookups.",
-    "6": "* Enhancement - Performance: Added cart product/category ID caching in checkout custom fields visibility checks.",
+    "1": "* Feature - WooCommerce Blocks: Checkout Custom Fields — radio fields are now automatically converted to select dropdowns on Blocks checkout. Batch option loading eliminates N+1 queries during field registration.",
+    "2": "* Feature - WooCommerce Blocks: Checkout Fees module now applies simple fees (fixed and percentage) on Blocks checkout via Store API. Checkout-field-conditional fees remain classic-only.",
+    "3": "* Enhancement - HPOS: Checkout Files Upload module refactored to use consolidated HPOS helper methods in email attachments, order display, and file-to-order paths. Store API hook added for Blocks-placed orders.",
+    "4": "* Enhancement - Performance: Added request-scope caching for checkout fee configuration to reduce repeated option lookups during cart calculation.",
+    "5": "* Enhancement - Performance: Added cart product and category ID caching in checkout custom fields visibility checks, reducing redundant cart iteration on classic checkout.",
+    "6": "* Note - Visibility conditions (product/category/cart-amount show/hide) and placement sections remain classic-checkout-only. WC Blocks API does not support cart-conditional field registration.",
     "7": "* WooCommerce 10.6.1 Tested",
     "8": "* WordPress 6.9.4 Tested"
 }

--- a/woocommerce-jetpack.php
+++ b/woocommerce-jetpack.php
@@ -4,7 +4,7 @@
  * Requires Plugins: woocommerce
  * Plugin URI: https://booster.io
  * Description: Supercharge your WooCommerce site with these awesome powerful features.
- * Version: 7.11.5
+ * Version: 8.0.0
  * Author: Pluggabl LLC
  * Author URI: https://booster.io
  * Text Domain: woocommerce-jetpack


### PR DESCRIPTION
## Summary

Coordinated **8.0.0** release — Compatibility + Performance Confidence Release.

### Pillar 1 — Checkout Custom Fields Blocks Phase 2
- **Radio fields** automatically converted to select dropdowns on Blocks (WC Blocks API has no native radio)
- **Batch option loading** eliminates N+1 queries during field registration (constructor-cached)
- **Note:** Visibility conditions (product/category/cart-amount show/hide) and section placement remain classic-checkout-only. The WC Blocks additional checkout fields API registers fields globally at plugin init before cart context is available.

### Pillar 2 — Checkout Fees Blocks Support
- **Simple fees** (fixed + percentage, with cart quantity/total conditions) now apply on Blocks checkout via Store API
- **Store API detection** added for proper context handling
- **Checkout-field-conditional fees** explicitly unsupported on Blocks (correctly skip)
- **Request-scope caching** for all fee option lookups

### Pillar 3 — HPOS Cleanup (Checkout Files Upload)
- **HPOS helpers actively used**: `get_order_file_meta()`, `update_order_file_meta()`, `save_order_if_hpos()` wired into email attachments, order display, and file-to-order paths
- **Store API hook** added for Blocks-placed orders

### Pillar 4 — Performance Wave 2
- Batch option loading in Blocks checkout fields registration
- Request-scope fee option caching in checkout fees module
- Cart product/category ID caching in classic checkout `is_visible()` — cart iterated once per request instead of once per field per condition

## What is NOT supported in this release
- Visibility conditions (product/category/cart-amount) on Blocks checkout — classic-checkout-only
- Section placement (billing/shipping/account) on Blocks checkout — all fields use order/additional-information area
- Textarea, datepicker, weekpicker, timepicker, number fields on Blocks checkout
- Checkout-field-conditional fees on Blocks checkout
- Checkout Files Upload form on Blocks checkout
- Plugin-wide Blocks compatibility (this is module-specific)

## Fix round (Codex validation findings)
- Reverted Blocks field location to `order` — the `address` location caused billing/shipping duplication
- Removed Blocks visibility evaluation — ran too early, caused get_cart/wc_get_product misuse notices
- Wired cart caching helpers into active `is_visible()` path
- Wired HPOS helpers into 3 live code paths (no longer dead code)
- Corrected all release wording to match actual behavior

## Test plan
- [ ] Classic checkout: text/select/checkbox/radio fields render and save correctly
- [ ] Blocks checkout: text/select/checkbox fields render; radio appears as select
- [ ] Blocks checkout: fields all appear in additional-information area (no billing/shipping duplication)
- [ ] Blocks checkout: simple checkout fee appears in order review
- [ ] Classic checkout: visibility conditions (category-gated field) work correctly
- [ ] HPOS on: checkout files upload saves correctly, admin shows files
- [ ] HPOS off: all existing behavior unchanged
- [ ] No get_cart/wc_get_product misuse notices in debug log
- [ ] PHP syntax: all files pass `php -l` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)