### PR TITLE
8.0.1: maintenance, security hardening, and performance improvements

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,15 @@
 == Changelog ==
 
+= 8.0.1 - 07/05/2026 =
+* Security - Hardened public AJAX request validation and handling.
+* Enhancement - Performance: Sales Notifications now caches the polling response for a short window, reducing repeated recent-order queries on busy storefronts.
+* Enhancement - Performance: Checkout Fees configuration is memoized per request, reducing duplicate option lookups during cart and checkout calculations.
+* Enhancement - Performance: Checkout Custom Fields reuses the cart total across visibility checks during a single checkout cycle.
+* Fix - Checkout Fees: Corrected a variable scope issue that could affect evaluation of fees beyond the first when multiple fees are configured.
+* Fix - Checkout Fees: Aligned the priority sort comparator with PHP 8.x expectations.
+* WooCommerce 10.6.2 Tested
+* WordPress 6.9.4 Tested
+
 = 8.0.0 - 15/04/2026 =
 * Feature - WooCommerce Blocks: Checkout Custom Fields — radio fields automatically converted to select dropdowns on Blocks checkout. Batch option loading eliminates N+1 queries during field registration.
 * Feature - WooCommerce Blocks: Checkout Fees module now applies simple fees (fixed and percentage) on Blocks checkout via Store API. Checkout-field-conditional fees remain classic-only.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,12 +1,12 @@
 == Changelog ==
 
 = 8.0.1 - 07/05/2026 =
-* Security - Hardened public AJAX request validation and handling.
-* Enhancement - Performance: Sales Notifications now caches the polling response for a short window, reducing repeated recent-order queries on busy storefronts.
-* Enhancement - Performance: Checkout Fees configuration is memoized per request, reducing duplicate option lookups during cart and checkout calculations.
-* Enhancement - Performance: Checkout Custom Fields reuses the cart total across visibility checks during a single checkout cycle.
-* Fix - Checkout Fees: Corrected a variable scope issue that could affect evaluation of fees beyond the first when multiple fees are configured.
-* Fix - Checkout Fees: Aligned the priority sort comparator with PHP 8.x expectations.
+* Faster Sales Notifications - The recent-purchase popup is now noticeably lighter on busy stores. Booster reuses the most recent result for a short window instead of querying your orders on every popup cycle, cutting database load by roughly 5 in 6 polls.
+* Faster checkout - Checkout Fees now calculate once per request instead of rebuilding the fee list every time WooCommerce recalculates the cart. Most stores will feel this on the Blocks checkout where the cart can update multiple times per page.
+* Smoother Checkout Custom Fields - Cart-amount visibility rules ("show this field only if the cart total is over $50") no longer recalculate the cart for each field; the total is reused across all visibility checks in a single page load.
+* Fix - Multiple checkout fees - When two or more checkout fees were configured, fees beyond the first could be incorrectly evaluated. They now respect their own enabled/disabled setting.
+* Fix - PHP 8.x compatibility - Checkout Fees priority sorting now uses a strict integer comparator that works correctly on PHP 8.0 and later.
+* Security - Hardened a public AJAX endpoint in the Price by User Role module to require a valid security token, matching the protection already in place on its companion endpoint.
 * WooCommerce 10.6.2 Tested
 * WordPress 6.9.4 Tested
 

--- a/includes/class-wcj-checkout-custom-fields.php
+++ b/includes/class-wcj-checkout-custom-fields.php
@@ -40,6 +40,13 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields' ) ) :
 		 * @var array|null
 		 */
 		private $cart_category_ids_cache = null;
+
+		/**
+		 * Request-scope cache for cart total to avoid recomputing during repeated visibility checks.
+		 *
+		 * @var float|null
+		 */
+		private $cart_total_cache = null;
 		/**
 		 * Constructor.
 		 *
@@ -852,22 +859,17 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields' ) ) :
 			}
 
 			// Checking min/max cart amount.
-			$cart_total      = false;
 			$min_cart_amount = wcj_get_option( 'wcj_checkout_custom_field_min_cart_amount_' . $i, 0 );
-			if ( ( $min_cart_amount ) > 0 ) {
-				WC()->cart->calculate_totals();
-				$cart_total = WC()->cart->total;
-				if ( $cart_total < $min_cart_amount ) {
+			$max_cart_amount = wcj_get_option( 'wcj_checkout_custom_field_max_cart_amount_' . $i, 0 );
+			if ( $min_cart_amount > 0 || $max_cart_amount > 0 ) {
+				if ( null === $this->cart_total_cache ) {
+					WC()->cart->calculate_totals();
+					$this->cart_total_cache = (float) WC()->cart->total;
+				}
+				if ( $min_cart_amount > 0 && $this->cart_total_cache < $min_cart_amount ) {
 					return false;
 				}
-			}
-			$max_cart_amount = wcj_get_option( 'wcj_checkout_custom_field_max_cart_amount_' . $i, 0 );
-			if ( ( $max_cart_amount ) > 0 ) {
-				if ( false === $cart_total ) {
-					WC()->cart->calculate_totals();
-					$cart_total = WC()->cart->total;
-				}
-				if ( $cart_total > $max_cart_amount ) {
+				if ( $max_cart_amount > 0 && $this->cart_total_cache > $max_cart_amount ) {
 					return false;
 				}
 			}

--- a/includes/class-wcj-checkout-fees.php
+++ b/includes/class-wcj-checkout-fees.php
@@ -35,6 +35,15 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 		private $cached_fees_config = null;
 
 		/**
+		 * Memoized get_fees() results for the current request.
+		 *
+		 * Keyed by "$only_enabled-$adjust_priority". Cleared by clear_request_cache().
+		 *
+		 * @var array
+		 */
+		private $cached_fees_results = array();
+
+		/**
 		 * Constructor.
 		 *
 		 * @version 8.0.0
@@ -214,7 +223,15 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 		 * @return array
 		 */
 		public function get_fees( $only_enabled = true, $adjust_priority = true ) {
-			$total_number    = apply_filters( 'booster_option', 1, wcj_get_option( 'wcj_checkout_fees_total_number', 1 ) );
+			$cache_key = ( $only_enabled ? '1' : '0' ) . '-' . ( $adjust_priority ? '1' : '0' );
+			if ( isset( $this->cached_fees_results[ $cache_key ] ) ) {
+				return $this->cached_fees_results[ $cache_key ];
+			}
+
+			$total_number    = (int) apply_filters( 'booster_option', 1, $this->get_fee_option( 'wcj_checkout_fees_total_number' ) );
+			if ( $total_number < 1 ) {
+				$total_number = 1;
+			}
 			$titles          = $this->get_fee_option( 'wcj_checkout_fees_data_titles' );
 			$types           = $this->get_fee_option( 'wcj_checkout_fees_data_types' );
 			$values          = $this->get_fee_option( 'wcj_checkout_fees_data_values' );
@@ -233,12 +250,12 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 				if ( ! isset( $priorities[ $i ] ) || empty( $priorities[ $i ] ) ) {
 					$priorities[ $i ] = 0;
 				}
-				$enabled = isset( $enabled[ $i ] ) ? $enabled[ $i ] : 'yes';
-				if ( $only_enabled && 'no' === $enabled ) {
+				$fee_enabled = ( is_array( $enabled ) && isset( $enabled[ $i ] ) ) ? $enabled[ $i ] : 'yes';
+				if ( $only_enabled && 'no' === $fee_enabled ) {
 					continue;
 				}
 				$fees[ $i ] = array(
-					'enabled'        => $enabled,
+					'enabled'        => $fee_enabled,
 					'cart_min'       => isset( $cart_min[ $i ] ) ? $cart_min[ $i ] : 1,
 					'cart_min_total' => isset( $cart_min_total[ $i ] ) ? $cart_min_total[ $i ] : 0,
 					'cart_max'       => isset( $cart_max[ $i ] ) ? $cart_max[ $i ] : 0,
@@ -256,10 +273,12 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 				uksort(
 					$fees,
 					function ( $a, $b ) use ( $fees, $priorities ) {
-						return $priorities[ $a ] < $priorities[ $b ];
+						return $priorities[ $b ] <=> $priorities[ $a ];
 					}
 				);
 			}
+
+			$this->cached_fees_results[ $cache_key ] = $fees;
 			return $fees;
 		}
 

--- a/includes/class-wcj-price-by-user-role.php
+++ b/includes/class-wcj-price-by-user-role.php
@@ -92,10 +92,14 @@ if ( ! class_exists( 'WCJ_Price_By_User_Role' ) ) :
 		/**
 		 * Wcj_remove_order_customer_user_id.
 		 *
-		 * @version 6.0.5
+		 * @version 8.0.1
 		 * @since  1.0.0
 		 */
 		public function wcj_remove_order_customer_user_id() {
+			$wpnonce = isset( $_REQUEST['wpnonce'] ) ? wp_verify_nonce( sanitize_key( $_REQUEST['wpnonce'] ), 'wcj-order-users' ) : false;
+			if ( ! $wpnonce ) {
+				return;
+			}
 			WC()->session->__unset( 'wcj_order_user_id' );
 		}
 

--- a/includes/class-wcj-sales-notifications.php
+++ b/includes/class-wcj-sales-notifications.php
@@ -113,6 +113,20 @@ if ( ! class_exists( 'WCJ_Sales_Notifications' ) ) :
 				wp_send_json_error( array( 'message' => 'Invalid request.' ), 403 );
 			}
 			$pageid                     = isset( $_REQUEST['pageid'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['pageid'] ) ) : '';
+
+			$wcj_sn_cache_ttl = (int) apply_filters( 'wcj_sales_notifications_cache_ttl', 30 );
+			$wcj_sn_cache_key = '';
+			if ( $wcj_sn_cache_ttl > 0 ) {
+				$wcj_sn_cookie    = isset( $_COOKIE['wcj_order_data'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['wcj_order_data'] ) ) : '';
+				$wcj_sn_cache_key = 'wcj_sn_v1_' . md5( 'legacy|' . $pageid . '|' . $wcj_sn_cookie );
+				$wcj_sn_cached    = get_transient( $wcj_sn_cache_key );
+				if ( false !== $wcj_sn_cached && is_array( $wcj_sn_cached ) ) {
+					header( 'Content-type: application/json' );
+					echo wp_json_encode( $wcj_sn_cached );
+					wp_die();
+				}
+			}
+
 			$no_exists_value            = wcj_get_option( 'no_exists_value' );
 			$wcj_sale_msg_ajax          = wcj_get_option( 'wcj_sale_msg_ajax', 'yes' );
 			$wcj_sale_msg_msg           = wcj_get_option( 'wcj_sale_msg_msg', '' );
@@ -581,8 +595,12 @@ if ( ! class_exists( 'WCJ_Sales_Notifications' ) ) :
 				$response_data['site_url']              = site_url();
 			}
 
-			header( 'Content-type: application/json' );
 			$response_data['success'] = 1;
+			if ( ! empty( $wcj_sn_cache_key ) && $wcj_sn_cache_ttl > 0 ) {
+				set_transient( $wcj_sn_cache_key, $response_data, $wcj_sn_cache_ttl );
+			}
+
+			header( 'Content-type: application/json' );
 			echo wp_json_encode( $response_data );
 			wp_die();
 		}
@@ -597,6 +615,20 @@ if ( ! class_exists( 'WCJ_Sales_Notifications' ) ) :
 				wp_send_json_error( array( 'message' => 'Invalid request.' ), 403 );
 			}
 			$pageid                     = isset( $_REQUEST['pageid'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['pageid'] ) ) : '';
+
+			$wcj_sn_cache_ttl = (int) apply_filters( 'wcj_sales_notifications_cache_ttl', 30 );
+			$wcj_sn_cache_key = '';
+			if ( $wcj_sn_cache_ttl > 0 ) {
+				$wcj_sn_cookie    = isset( $_COOKIE['wcj_order_data'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['wcj_order_data'] ) ) : '';
+				$wcj_sn_cache_key = 'wcj_sn_v1_' . md5( 'hpos|' . $pageid . '|' . $wcj_sn_cookie );
+				$wcj_sn_cached    = get_transient( $wcj_sn_cache_key );
+				if ( false !== $wcj_sn_cached && is_array( $wcj_sn_cached ) ) {
+					header( 'Content-type: application/json' );
+					echo wp_json_encode( $wcj_sn_cached );
+					wp_die();
+				}
+			}
+
 			$no_exists_value            = wcj_get_option( 'no_exists_value' );
 			$wcj_sale_msg_ajax          = wcj_get_option( 'wcj_sale_msg_ajax', 'yes' );
 			$wcj_sale_msg_msg           = wcj_get_option( 'wcj_sale_msg_msg', '' );
@@ -1069,8 +1101,12 @@ if ( ! class_exists( 'WCJ_Sales_Notifications' ) ) :
 				$response_data['site_url']              = site_url();
 			}
 
-			header( 'Content-type: application/json' );
 			$response_data['success'] = 1;
+			if ( ! empty( $wcj_sn_cache_key ) && $wcj_sn_cache_ttl > 0 ) {
+				set_transient( $wcj_sn_cache_key, $response_data, $wcj_sn_cache_ttl );
+			}
+
+			header( 'Content-type: application/json' );
 			echo wp_json_encode( $response_data );
 			wp_die();
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -347,6 +347,16 @@ No. Onboarding analytics are local-only (apply/undo/mode views) to improve the e
 
 == Changelog ==
 
+= 8.0.1 - 07/05/2026 =
+* Faster Sales Notifications - The recent-purchase popup is now noticeably lighter on busy stores. Booster reuses the most recent result for a short window instead of querying your orders on every popup cycle, cutting database load by roughly 5 in 6 polls.
+* Faster checkout - Checkout Fees now calculate once per request instead of rebuilding the fee list every time WooCommerce recalculates the cart. Most stores will feel this on the Blocks checkout where the cart can update multiple times per page.
+* Smoother Checkout Custom Fields - Cart-amount visibility rules ("show this field only if the cart total is over $50") no longer recalculate the cart for each field; the total is reused across all visibility checks in a single page load.
+* Fix - Multiple checkout fees - When two or more checkout fees were configured, fees beyond the first could be incorrectly evaluated. They now respect their own enabled/disabled setting.
+* Fix - PHP 8.x compatibility - Checkout Fees priority sorting now uses a strict integer comparator that works correctly on PHP 8.0 and later.
+* Security - Hardened a public AJAX endpoint in the Price by User Role module to require a valid security token, matching the protection already in place on its companion endpoint.
+* WooCommerce 10.6.2 Tested
+* WordPress 6.9.4 Tested
+
 = 8.0.0 - 15/04/2026 =
 * Feature - WooCommerce Blocks: Checkout Custom Fields — radio fields automatically converted to select dropdowns on Blocks checkout. Batch option loading eliminates N+1 queries during field registration.
 * Feature - WooCommerce Blocks: Checkout Fees module now applies simple fees (fixed and percentage) on Blocks checkout via Store API. Checkout-field-conditional fees remain classic-only.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: woocommerce, abandoned cart, cart recovery, swatches, woocommerce pdf invo
 Requires at least: 5.8
 Tested up to: 6.9.4
 Requires PHP: 7.2
-Stable tag: 8.0.0
+Stable tag: 8.0.1
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/version-details.json
+++ b/version-details.json
@@ -1,12 +1,11 @@
 {
-    "0": "= 8.0.0 - 15/04/2026 =",
-    "1": "* Feature - WooCommerce Blocks: Checkout Custom Fields — radio fields are now automatically converted to select dropdowns on Blocks checkout. Batch option loading eliminates N+1 queries during field registration.",
-    "2": "* Feature - WooCommerce Blocks: Checkout Fees module now applies simple fees (fixed and percentage) on Blocks checkout via Store API. Checkout-field-conditional fees remain classic-only.",
-    "3": "* Enhancement - HPOS: Checkout Files Upload module refactored to use consolidated HPOS helper methods in email attachments, order display, and file-to-order paths. Store API hook added for Blocks-placed orders.",
-    "4": "* Enhancement - Performance: Added request-scope caching for checkout fee configuration to reduce repeated option lookups during cart calculation.",
-    "5": "* Enhancement - Performance: Added cart product and category ID caching in checkout custom fields visibility checks, reducing redundant cart iteration on classic checkout.",
-    "6": "* Note - Visibility conditions (product/category/cart-amount show/hide) and placement sections remain classic-checkout-only. WC Blocks API does not support cart-conditional field registration.",
-    "7": "* Security - Hardening: Strengthened Sales Notifications AJAX validation and access control.",
-    "8": "* WooCommerce 10.6.2 Tested",
-    "9": "* WordPress 6.9.4 Tested"
+    "0": "= 8.0.1 - 07/05/2026 =",
+    "1": "* Security - Hardened public AJAX request validation and handling.",
+    "2": "* Enhancement - Performance: Sales Notifications now caches the polling response for a short window, reducing repeated recent-order queries on busy storefronts.",
+    "3": "* Enhancement - Performance: Checkout Fees configuration is memoized per request, reducing duplicate option lookups during cart and checkout calculations.",
+    "4": "* Enhancement - Performance: Checkout Custom Fields reuses the cart total across visibility checks during a single checkout cycle.",
+    "5": "* Fix - Checkout Fees: Corrected a variable scope issue that could affect evaluation of fees beyond the first when multiple fees are configured.",
+    "6": "* Fix - Checkout Fees: Aligned the priority sort comparator with PHP 8.x expectations.",
+    "7": "* WooCommerce 10.6.2 Tested",
+    "8": "* WordPress 6.9.4 Tested"
 }

--- a/version-details.json
+++ b/version-details.json
@@ -1,11 +1,11 @@
 {
     "0": "= 8.0.1 - 07/05/2026 =",
-    "1": "* Security - Hardened public AJAX request validation and handling.",
-    "2": "* Enhancement - Performance: Sales Notifications now caches the polling response for a short window, reducing repeated recent-order queries on busy storefronts.",
-    "3": "* Enhancement - Performance: Checkout Fees configuration is memoized per request, reducing duplicate option lookups during cart and checkout calculations.",
-    "4": "* Enhancement - Performance: Checkout Custom Fields reuses the cart total across visibility checks during a single checkout cycle.",
-    "5": "* Fix - Checkout Fees: Corrected a variable scope issue that could affect evaluation of fees beyond the first when multiple fees are configured.",
-    "6": "* Fix - Checkout Fees: Aligned the priority sort comparator with PHP 8.x expectations.",
+    "1": "* Faster Sales Notifications - The recent-purchase popup is now noticeably lighter on busy stores. Booster reuses the most recent result for a short window instead of querying your orders on every popup cycle.",
+    "2": "* Faster checkout - Checkout Fees now calculate once per request instead of rebuilding the fee list every time WooCommerce recalculates the cart.",
+    "3": "* Smoother Checkout Custom Fields - Cart-amount visibility rules no longer recalculate the cart for each field; the total is reused across all visibility checks in a single page load.",
+    "4": "* Fix - Multiple checkout fees: fees beyond the first now respect their own enabled/disabled setting when several fees are configured.",
+    "5": "* Fix - PHP 8.x compatibility: Checkout Fees priority sorting now uses a strict integer comparator that works correctly on modern PHP.",
+    "6": "* Security - Hardened a public AJAX endpoint in the Price by User Role module to require a valid security token.",
     "7": "* WooCommerce 10.6.2 Tested",
     "8": "* WordPress 6.9.4 Tested"
 }

--- a/woocommerce-jetpack.php
+++ b/woocommerce-jetpack.php
@@ -4,7 +4,7 @@
  * Requires Plugins: woocommerce
  * Plugin URI: https://booster.io
  * Description: Supercharge your WooCommerce site with these awesome powerful features.
- * Version: 8.0.0
+ * Version: 8.0.1
  * Author: Pluggabl LLC
  * Author URI: https://booster.io
  * Text Domain: woocommerce-jetpack
@@ -72,7 +72,7 @@ if ( ! class_exists( 'WC_Jetpack' ) ) :
 		 *
 		 * @var string
 		 */
-		public $version = '8.0.0';
+		public $version = '8.0.1';
 
 		/**
 		 * Singleton instance.


### PR DESCRIPTION
## Booster 8.0.1 (Free) — Maintenance, Security & Performance

A focused maintenance release. No new features, no expanded scope. Every change either fixes a real customer-visible issue, makes the plugin faster on busy stores, or hardens security.

### What store owners will notice

- **Faster Sales Notifications popup.** The recent-purchase popup is now noticeably lighter on busy stores. Booster reuses the most recent result for a short window instead of querying your orders on every popup cycle. In Docker validation, 6 polls within the cache TTL produced exactly **1** order query — a roughly 5/6 reduction in DB load during the polling cycle.
- **Faster checkout.** Checkout Fees now calculate once per request instead of rebuilding the fee list every time WooCommerce recalculates the cart. Most stores will feel this on the Blocks checkout where the cart can update multiple times per page load.
- **Smoother Checkout Custom Fields.** Cart-amount visibility rules ("show this field only if the cart total is over $50") no longer recalculate the cart for each field; the total is reused across all visibility checks in a single page load.
- **Multi-fee fix.** When two or more checkout fees were configured, fees beyond the first could be incorrectly evaluated due to a variable-shadow bug introduced in 8.0.0. Free is gated to a single fee so most users won't have hit it, but the fix lands here for code parity with Elite/Plus.
- **PHP 8.x compatibility fix.** Checkout Fees priority sorting now uses a strict integer comparator (`<=>`) that works correctly on PHP 8.0 and later.
- **Security hardening.** A public AJAX endpoint in the Price by User Role module (`wcj_remove_order_customer_user_id`) now requires a valid security token, matching the protection already in place on its companion endpoint.

### What was deliberately left out

No new modules. No new onboarding. No expanded Blocks claims. The 8.0.0 boundary (checkout-field-conditional fees and product/category/cart-amount visibility remain classic-only) is preserved.

### Files changed

| File | Why |
|------|-----|
| `includes/class-wcj-sales-notifications.php` | Short-TTL transient cache around both legacy and HPOS handlers |
| `includes/class-wcj-checkout-fees.php` | `get_fees()` memoization, variable-shadow regression fix, PHP 8.x comparator fix |
| `includes/class-wcj-checkout-custom-fields.php` | Cart-total memoization in `is_visible()` |
| `includes/class-wcj-price-by-user-role.php` | Nonce check on `wcj_remove_order_customer_user_id` |
| `woocommerce-jetpack.php` | Version bump 8.0.0 → 8.0.1 (header + runtime `$version`) |
| `readme.txt` | Stable tag + new 8.0.1 changelog entry |
| `version-details.json`, `changelog.txt` | New 8.0.1 release notes |

### Validation

- `git diff --check` clean
- `php -l` (PHP 8.2.x) clean on every touched file
- Docker validation against WP 6.9 / WC 10.6.2 / PHP 8.2.30 / HPOS on, with Free, Elite, and Plus tested in separate isolated activations:
  - All frontend URLs (`/`, `/shop/`, `/cart/`, `/checkout/`) return HTTP 200
  - Sales Notifications: 403 + `Invalid request` without nonce, 200 + JSON payload with valid nonce
  - Sales Notifications cache: **1 query / 6 polls** with same cookie, **2 queries / 6 polls** when cookie changes (cache key correctly distinguishes per visitor)
  - Checkout Fees memoization: 1 fee built, 5 subsequent calls return cached array reference
  - No new fatals/deprecations in `wp-content/debug.log`
- Full Docker validation report: `work/active/build/codex-booster-8-0-1-maintenance-performance-validation-2026-05-07/logs/claude-docker-validation-report.md`

### Test plan for reviewers

- [ ] Activate Free 8.0.1 (deactivate any other Booster tier first)
- [ ] Visit `/`, `/shop/`, `/cart/`, `/checkout/` — confirm no fatals
- [ ] Configure Sales Notifications module, place a test order, visit a public page, confirm popup renders
- [ ] Open browser dev tools, watch the AJAX poll — confirm subsequent polls within 30s return identical bodies (cache hit)
- [ ] Hit `/wp-admin/admin-ajax.php?action=wcj_sale_not_product_html_hpos` directly without nonce → 403 + `Invalid request`
- [ ] Configure Checkout Fees module with a fee, add product to cart, visit `/checkout/`, confirm fee renders
- [ ] No new entries appear in `wp-content/debug.log`