### PR TITLE
8.0.2: Free checkout compatibility and reliability maintenance

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 == Changelog ==
 
 = 8.0.2 - 15/06/2026 =
-* Security - Hardened Product by User image uploads so customer-submitted product images are validated as real allowed image files before they can be moved into uploads.
+* Security - Hardened Product by User image uploads so customer-submitted product images are validated as real allowed image files before they can be moved into uploads, and Free keeps paid image upload fields disabled even if a request is manually crafted.
 * Security hardening - Strengthened related customer upload validation in Checkout Files Upload and Product Input Fields.
 * Continuous improvement - Free stores get safer Product Addons selection handling: radio/select choices now use stable submitted values while older cached forms remain compatible.
 * Checkout confidence - Booster now shows admin-only compatibility status when active checkout modules need Classic Checkout, Checkout Blocks staging, or HPOS review.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,8 @@
 == Changelog ==
 
 = 8.0.2 - 15/06/2026 =
+* Security - Hardened Product by User image uploads so customer-submitted product images are validated as real allowed image files before they can be moved into uploads.
+* Security hardening - Strengthened related customer upload validation in Checkout Files Upload and Product Input Fields.
 * Continuous improvement - Free stores get safer Product Addons selection handling: radio/select choices now use stable submitted values while older cached forms remain compatible.
 * Checkout confidence - Booster now shows admin-only compatibility status when active checkout modules need Classic Checkout, Checkout Blocks staging, or HPOS review.
 * Reliability - Order Numbers and PDF Invoicing now prefer WooCommerce order APIs for maintained order meta reads/writes, with legacy fallbacks for older stores.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 == Changelog ==
 
 = 8.0.2 - 15/06/2026 =
-* Security - Hardened Product by User image uploads so customer-submitted product images are validated as real allowed image files before they can be moved into uploads, and Free keeps paid image upload fields disabled even if a request is manually crafted.
+* Security - Hardened Product by User media upload handling and Free tier upload boundaries.
 * Security hardening - Strengthened related customer upload validation in Checkout Files Upload and Product Input Fields.
 * Continuous improvement - Free stores get safer Product Addons selection handling: radio/select choices now use stable submitted values while older cached forms remain compatible.
 * Checkout confidence - Booster now shows admin-only compatibility status when active checkout modules need Classic Checkout, Checkout Blocks staging, or HPOS review.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,12 @@
 == Changelog ==
 
+= 8.0.2 - 15/06/2026 =
+* Continuous improvement - Free stores get safer Product Addons selection handling: radio/select choices now use stable submitted values while older cached forms remain compatible.
+* Checkout confidence - Booster now shows admin-only compatibility status when active checkout modules need Classic Checkout, Checkout Blocks staging, or HPOS review.
+* Reliability - Order Numbers and PDF Invoicing now prefer WooCommerce order APIs for maintained order meta reads/writes, with legacy fallbacks for older stores.
+* Performance - Product Addons settings are cached for the current request to reduce repeated option reads during cart and checkout calculations.
+* Value - The Free feature set keeps its documented limits while receiving maintenance hardening on shared module paths.
+
 = 8.0.1 - 07/05/2026 =
 * Faster Sales Notifications - The recent-purchase popup is now noticeably lighter on busy stores. Booster reuses the most recent result for a short window instead of querying your orders on every popup cycle, cutting database load by roughly 5 in 6 polls.
 * Faster checkout - Checkout Fees now calculate once per request instead of rebuilding the fee list every time WooCommerce recalculates the cart. Most stores will feel this on the Blocks checkout where the cart can update multiple times per page.

--- a/includes/class-wcj-checkout-files-upload.php
+++ b/includes/class-wcj-checkout-files-upload.php
@@ -860,12 +860,12 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 					}
 
 					// Extra security check: Restrict for malicious file types.
-					$validate = wp_check_filetype( $real_file_name );
+					$validate = wp_check_filetype_and_ext( $temp_file_name, $real_file_name );
 					if ( false === $validate['type'] ) {
 						$this->add_notice(
 							sprintf(
 								// translators: %s is the file type that is not allowed.
-								__( 'File type is not allowed: "%s".', 'plugin-slug' ),
+								__( 'File type is not allowed: "%s".', 'woocommerce-jetpack' ),
 								$real_file_name
 							),
 							'error'

--- a/includes/class-wcj-compatibility-status.php
+++ b/includes/class-wcj-compatibility-status.php
@@ -1,0 +1,340 @@
+<?php
+/**
+ * Booster for WooCommerce - Compatibility Status
+ *
+ * @version 8.0.2
+ * @since   8.0.2
+ * @author  Pluggabl LLC.
+ * @package Booster_For_WooCommerce/includes
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'WCJ_Compatibility_Status' ) ) :
+	/**
+	 * Admin-only compatibility status guidance for checkout architecture and HPOS.
+	 */
+	class WCJ_Compatibility_Status {
+
+		/**
+		 * Constructor.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 */
+		public function __construct() {
+			add_action( 'admin_notices', array( $this, 'maybe_show_admin_notice' ) );
+		}
+
+		/**
+		 * Shows module-specific compatibility guidance on Booster admin screens only.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 */
+		public function maybe_show_admin_notice() {
+			if ( ! $this->is_booster_admin_screen() ) {
+				return;
+			}
+
+			$checkout_status = $this->detect_checkout_architecture();
+			$blocks_modules  = $this->get_active_checkout_modules();
+			$hpos_modules    = $this->get_active_hpos_modules();
+
+			if ( 'blocks' === $checkout_status && ! empty( $blocks_modules ) ) {
+				$this->render_notice(
+					'warning',
+					__( 'Booster checkout compatibility status', 'woocommerce-jetpack' ),
+					__( 'Booster detected WooCommerce Checkout Blocks on this store. The active modules below are module-specific; keep using Classic Checkout where noted or test the flow in staging before release.', 'woocommerce-jetpack' ),
+					$blocks_modules
+				);
+			}
+
+			if ( $this->is_hpos_enabled() && ! empty( $hpos_modules ) ) {
+				$this->render_notice(
+					'info',
+					__( 'Booster HPOS compatibility status', 'woocommerce-jetpack' ),
+					__( 'High-Performance Order Storage is enabled. These active order modules use WooCommerce order APIs in the maintained paths, but custom order workflows should still be tested in staging.', 'woocommerce-jetpack' ),
+					$hpos_modules
+				);
+			}
+		}
+
+		/**
+		 * Detects if the current checkout page uses Checkout Blocks, Classic Checkout, or cannot be detected.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @return string
+		 */
+		protected function detect_checkout_architecture() {
+			if ( ! function_exists( 'wc_get_page_id' ) ) {
+				return 'unknown';
+			}
+
+			$checkout_page_id = wc_get_page_id( 'checkout' );
+			if ( $checkout_page_id <= 0 ) {
+				return 'unknown';
+			}
+
+			$post = get_post( $checkout_page_id );
+			if ( ! $post || empty( $post->post_content ) ) {
+				return 'unknown';
+			}
+
+			if ( function_exists( 'has_block' ) && has_block( 'woocommerce/checkout', $post ) ) {
+				return 'blocks';
+			}
+
+			if ( false !== strpos( $post->post_content, '<!-- wp:woocommerce/checkout' ) || false !== strpos( $post->post_content, 'wp:woocommerce/checkout' ) ) {
+				return 'blocks';
+			}
+
+			if ( has_shortcode( $post->post_content, 'woocommerce_checkout' ) ) {
+				return 'classic';
+			}
+
+			return 'unknown';
+		}
+
+		/**
+		 * Checks whether HPOS is enabled.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @return bool
+		 */
+		protected function is_hpos_enabled() {
+			return function_exists( 'wcj_is_hpos_enabled' ) && true === wcj_is_hpos_enabled();
+		}
+
+		/**
+		 * Returns active Checkout Blocks sensitive modules.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @return array
+		 */
+		protected function get_active_checkout_modules() {
+			$modules = array(
+				array(
+					'id'    => 'checkout_fees',
+					'label' => __( 'Checkout Fees', 'woocommerce-jetpack' ),
+					'note'  => __( 'Simple fixed and percentage fees are maintained for Blocks; checkout-field-conditional fees remain a Classic Checkout/staging item.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'    => 'checkout_custom_fields',
+					'label' => __( 'Checkout Custom Fields', 'woocommerce-jetpack' ),
+					'note'  => __( 'Basic fields are Blocks-aware; richer visibility and placement rules should be confirmed on Classic Checkout or in staging.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'    => 'checkout_files_upload',
+					'label' => __( 'Checkout Files Upload', 'woocommerce-jetpack' ),
+					'note'  => __( 'Store API order attachment paths are maintained; file upload placement and validation should be tested with the exact checkout flow.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'    => 'product_addons',
+					'label' => __( 'Product Addons', 'woocommerce-jetpack' ),
+					'note'  => __( 'Addon choices now use safer submitted values and structured cart data; test add-to-cart, checkout, and order meta with your enabled tier limits.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'    => 'eu_vat_number',
+					'label' => __( 'EU VAT Number', 'woocommerce-jetpack' ),
+					'note'  => __( 'VAT capture and validation remain checkout-flow sensitive; Classic Checkout is recommended unless the exact Blocks flow has been staged.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'    => 'payment_gateways',
+					'label' => __( 'Custom Payment Gateways', 'woocommerce-jetpack' ),
+					'note'  => __( 'Gateway visibility and order data should be checked with the active checkout architecture before release.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'    => 'payment_gateways_by_country',
+					'label' => __( 'Payment Gateways by Country', 'woocommerce-jetpack' ),
+					'note'  => __( 'Gateway filters depend on checkout customer data; test the live shipping/billing scenario in staging.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'    => 'payment_gateways_by_currency',
+					'label' => __( 'Payment Gateways by Currency', 'woocommerce-jetpack' ),
+					'note'  => __( 'Gateway filters depend on the active currency; test the currency switcher and checkout together.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'    => 'payment_gateways_by_shipping',
+					'label' => __( 'Payment Gateways by Shipping', 'woocommerce-jetpack' ),
+					'note'  => __( 'Gateway filters depend on selected shipping methods; test after shipping rates are available in the checkout flow.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'    => 'payment_gateways_by_user_role',
+					'label' => __( 'Payment Gateways by User Role', 'woocommerce-jetpack' ),
+					'note'  => __( 'Gateway filters depend on customer session state; test guest and signed-in roles separately.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'    => 'payment_gateways_min_max',
+					'label' => __( 'Gateways Min/Max Amounts', 'woocommerce-jetpack' ),
+					'note'  => __( 'Gateway filters depend on recalculated cart totals; test below, inside, and above each configured threshold.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'    => 'payment_gateways_per_category',
+					'label' => __( 'Gateways by Product or Category', 'woocommerce-jetpack' ),
+					'note'  => __( 'Gateway filters depend on cart contents; test carts with matching and non-matching products/categories.', 'woocommerce-jetpack' ),
+				),
+			);
+
+			return $this->filter_active_modules( $modules );
+		}
+
+		/**
+		 * Returns active HPOS-sensitive modules.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @return array
+		 */
+		protected function get_active_hpos_modules() {
+			$modules = array(
+				array(
+					'id'    => 'order_numbers',
+					'label' => __( 'Order Numbers', 'woocommerce-jetpack' ),
+					'note'  => __( 'Order-number reads and writes now prefer WooCommerce order meta APIs with a legacy fallback.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'    => 'pdf_invoicing',
+					'label' => __( 'PDF Invoicing', 'woocommerce-jetpack' ),
+					'note'  => __( 'Order-owner checks now read the customer through WooCommerce order APIs with a legacy fallback.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'    => 'checkout_files_upload',
+					'label' => __( 'Checkout Files Upload', 'woocommerce-jetpack' ),
+					'note'  => __( 'Order attachment paths should be checked against the store\'s upload hooks and order emails.', 'woocommerce-jetpack' ),
+				),
+			);
+
+			return $this->filter_active_modules( $modules );
+		}
+
+		/**
+		 * Filters module definitions to active modules only.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @param array $modules defines module definitions.
+		 * @return array
+		 */
+		protected function filter_active_modules( $modules ) {
+			$active = array();
+
+			foreach ( $modules as $module ) {
+				if ( $this->is_module_enabled( $module['id'] ) ) {
+					$active[] = $module;
+				}
+			}
+
+			return $active;
+		}
+
+		/**
+		 * Checks whether a module is enabled without changing tier limits.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @param string $module_id defines the module ID.
+		 * @return bool
+		 */
+		protected function is_module_enabled( $module_id ) {
+			if ( function_exists( 'wcj_is_module_enabled' ) ) {
+				return wcj_is_module_enabled( $module_id );
+			}
+
+			return function_exists( 'wcj_get_option' ) && 'yes' === wcj_get_option( 'wcj_' . $module_id . '_enabled', 'no' );
+		}
+
+		/**
+		 * Renders a compatibility notice.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @param string $type defines the notice type.
+		 * @param string $title defines the notice title.
+		 * @param string $intro defines the notice intro.
+		 * @param array  $modules defines active module rows.
+		 */
+		protected function render_notice( $type, $title, $intro, $modules ) {
+			$notice_class = ( 'warning' === $type ) ? 'notice-warning' : 'notice-info';
+
+			echo '<div class="notice ' . esc_attr( $notice_class ) . ' wcj-compatibility-status">';
+			echo '<p><strong>' . esc_html( $title ) . '</strong></p>';
+			echo '<p>' . esc_html( $intro ) . '</p>';
+			echo '<ul style="list-style:disc;margin-left:20px;">';
+
+			foreach ( $modules as $module ) {
+				echo '<li><strong>' . esc_html( $module['label'] ) . ':</strong> ' . esc_html( $module['note'] ) . '</li>';
+			}
+
+			echo '</ul>';
+			echo '<p>' . esc_html( $this->get_tier_note() ) . '</p>';
+			echo '</div>';
+		}
+
+		/**
+		 * Returns tier-specific compatibility wording.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @return string
+		 */
+		protected function get_tier_note() {
+			$plugin_file = defined( 'WCJ_PLUGIN_FILE' ) ? WCJ_PLUGIN_FILE : ( defined( 'WCJ_FREE_PLUGIN_FILE' ) ? WCJ_FREE_PLUGIN_FILE : '' );
+			$basename    = basename( $plugin_file );
+
+			if ( 'woocommerce-jetpack.php' === $basename ) {
+				return __( 'Free tier note: this status reflects the documented Free feature set and limits; it does not unlock paid-only controls.', 'woocommerce-jetpack' );
+			}
+
+			if ( 'booster-plus-for-woocommerce.php' === $basename ) {
+				return __( 'Plus tier note: this status reflects the Plus feature set; Elite-only controls remain outside Plus.', 'woocommerce-jetpack' );
+			}
+
+			if ( 'booster-elite-for-woocommerce.php' === $basename ) {
+				return __( 'Elite tier note: this status reflects the full Elite feature set, with Blocks and HPOS guidance kept module-specific.', 'woocommerce-jetpack' );
+			}
+
+			return __( 'Tier note: compatibility guidance is module-specific and does not change enabled features or limits.', 'woocommerce-jetpack' );
+		}
+
+		/**
+		 * Checks whether the current admin screen belongs to Booster.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @return bool
+		 */
+		protected function is_booster_admin_screen() {
+			if ( ! is_admin() ) {
+				return false;
+			}
+
+			$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$tab  = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( $_GET['tab'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+			if ( 0 === strpos( $page, 'wcj-' ) ) {
+				return true;
+			}
+
+			if ( 'wc-settings' === $page && 'jetpack' === $tab ) {
+				return true;
+			}
+
+			$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+			if ( $screen && isset( $screen->id ) && false !== strpos( $screen->id, 'wcj' ) ) {
+				return true;
+			}
+
+			return false;
+		}
+	}
+endif;
+
+if ( is_admin() ) {
+	new WCJ_Compatibility_Status();
+}

--- a/includes/class-wcj-order-numbers.php
+++ b/includes/class-wcj-order-numbers.php
@@ -165,6 +165,47 @@ if ( ! class_exists( 'WCJ_Order_Numbers' ) ) :
 			return $tracking_links;
 		}
 
+
+		/**
+		 * Reads Booster order meta through WooCommerce order APIs when available.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @param int    $order_id defines the order ID.
+		 * @param string $meta_key defines the meta key.
+		 * @return mixed
+		 */
+		protected function get_booster_order_meta( $order_id, $meta_key ) {
+			$order = wcj_get_order( $order_id );
+
+			if ( $order && false !== $order && is_callable( array( $order, 'get_meta' ) ) ) {
+				return $order->get_meta( $meta_key, true );
+			}
+
+			return get_post_meta( $order_id, $meta_key, true );
+		}
+
+		/**
+		 * Writes Booster order meta through WooCommerce order APIs when available.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @param int    $order_id defines the order ID.
+		 * @param string $meta_key defines the meta key.
+		 * @param mixed  $meta_value defines the meta value.
+		 */
+		protected function update_booster_order_meta( $order_id, $meta_key, $meta_value ) {
+			$order = wcj_get_order( $order_id );
+
+			if ( $order && false !== $order && is_callable( array( $order, 'update_meta_data' ) ) ) {
+				$order->update_meta_data( $meta_key, $meta_value );
+				$order->save();
+				return;
+			}
+
+			update_post_meta( $order_id, $meta_key, $meta_value );
+		}
+
 		/**
 		 * Maybe_add_meta_box.
 		 *
@@ -180,7 +221,7 @@ if ( ! class_exists( 'WCJ_Order_Numbers' ) ) :
 			if ( true === wcj_is_hpos_enabled() && $wcj_order_number ) {
 				parent::add_meta_box();
 			} else {
-				if ( '' !== get_post_meta( $post->ID, '_wcj_order_number', true ) ) {
+				if ( '' !== $this->get_booster_order_meta( $post->ID, '_wcj_order_number' ) ) {
 					parent::add_meta_box();
 				}
 			}
@@ -492,7 +533,9 @@ if ( ! class_exists( 'WCJ_Order_Numbers' ) ) :
 				return;
 			}
 
-			if ( true === $do_overwrite || 0 === get_post_meta( $order_id, '_wcj_order_number', true ) || '' === get_post_meta( $order_id, '_wcj_order_number', true ) ) {
+			$existing_order_number = $this->get_booster_order_meta( $order_id, '_wcj_order_number' );
+
+			if ( true === $do_overwrite || 0 === $existing_order_number || '' === $existing_order_number ) {
 				if ( $order_id < wcj_get_option( 'wcj_order_numbers_min_order_id', 0 ) ) {
 					return;
 				}
@@ -507,7 +550,7 @@ if ( ! class_exists( 'WCJ_Order_Numbers' ) ) :
 						$result_update        = $wpdb->update( $wp_options_table, array( 'option_value' => ( $current_order_number + 1 ) ), array( 'option_name' => 'wcj_order_number_counter' ) );
 						if ( null !== $result_update || ( $current_order_number + 1 ) === $result_select->option_value ) {
 							$wpdb->query( 'COMMIT' ); // all ok.
-							update_post_meta( $order_id, '_wcj_order_number', apply_filters( 'wcj_order_number_meta', $current_order_number, $order_id ) );
+							$this->update_booster_order_meta( $order_id, '_wcj_order_number', apply_filters( 'wcj_order_number_meta', $current_order_number, $order_id ) );
 						} else {
 							$wpdb->query( 'ROLLBACK' ); // something went wrong, Rollback.
 						}
@@ -524,7 +567,7 @@ if ( ! class_exists( 'WCJ_Order_Numbers' ) ) :
 					} else { // 'no' === wcj_get_option( 'wcj_order_number_sequential_enabled', 'yes' ) // order ID.
 						$current_order_number = '';
 					}
-					update_post_meta( $order_id, '_wcj_order_number', apply_filters( 'wcj_order_number_meta', $current_order_number, $order_id ) );
+					$this->update_booster_order_meta( $order_id, '_wcj_order_number', apply_filters( 'wcj_order_number_meta', $current_order_number, $order_id ) );
 				}
 			}
 		}
@@ -563,7 +606,7 @@ if ( ! class_exists( 'WCJ_Order_Numbers' ) ) :
 							$result_update        = $wpdb->update( $wp_options_table, array( 'option_value' => ( $current_order_number + 1 ) ), array( 'option_name' => 'wcj_order_number_counter' ) );
 							if ( null !== $result_update || ( $current_order_number + 1 ) === $result_select->option_value ) {
 								$wpdb->query( 'COMMIT' ); // all ok.
-								$order->update_meta_data('_wcj_order_number', apply_filters( 'wcj_order_number_meta', $current_order_number, $order_id ) );
+								$order->update_meta_data( '_wcj_order_number', apply_filters( 'wcj_order_number_meta', $current_order_number, $order_id ) );
 							} else {
 								$wpdb->query( 'ROLLBACK' ); // something went wrong, Rollback.
 							}
@@ -622,7 +665,7 @@ if ( ! class_exists( 'WCJ_Order_Numbers' ) ) :
 					$i = 0;
 					foreach ( $order as $order_id ) {
 
-						$this->add_order_number_meta_hpos( $order[ $i ]->id, true );
+						$this->add_order_number_meta_hpos( $order_id, true );
 						$i++;
 					}
 				} else {

--- a/includes/class-wcj-pdf-invoicing.php
+++ b/includes/class-wcj-pdf-invoicing.php
@@ -531,6 +531,25 @@ if ( ! class_exists( 'WCJ_PDF_Invoicing' ) ) :
 			}
 		}
 
+
+		/**
+		 * Gets an order customer ID through WooCommerce order APIs when available.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @param int $order_id defines the order ID.
+		 * @return int
+		 */
+		protected function get_order_customer_id( $order_id ) {
+			$order = wc_get_order( $order_id );
+
+			if ( $order && is_callable( array( $order, 'get_customer_id' ) ) ) {
+				return (int) $order->get_customer_id();
+			}
+
+			return (int) get_post_meta( $order_id, '_customer_user', true );
+		}
+
 		/**
 		 * Check_user_roles.
 		 *
@@ -540,7 +559,7 @@ if ( ! class_exists( 'WCJ_PDF_Invoicing' ) ) :
 		 * @param  bool $allow_order_owner defines the allow_order_owner.
 		 */
 		public function check_user_roles( $allow_order_owner = true ) {
-			if ( is_user_logged_in() && $allow_order_owner && get_current_user_id() === intval( get_post_meta( $this->order_id, '_customer_user', true ) ) ) {
+			if ( is_user_logged_in() && $allow_order_owner && get_current_user_id() === $this->get_order_customer_id( $this->order_id ) ) {
 				return true;
 			}
 			$allowed_user_roles = wcj_get_option( 'wcj_invoicing_' . $this->invoice_type_id . '_roles', array( 'administrator', 'shop_manager' ) );

--- a/includes/class-wcj-product-addons.php
+++ b/includes/class-wcj-product-addons.php
@@ -33,6 +33,17 @@ if ( ! class_exists( 'WCJ_Product_Addons' ) ) :
 		 */
 		public $are_addons_displayed;
 
+
+		/**
+		 * Request-scope Product Addons configuration cache.
+		 *
+		 * Keeps repeated cart/checkout calls from rebuilding the same addon map
+		 * without persisting potentially stale per-product settings across requests.
+		 *
+		 * @var array
+		 */
+		protected $product_addons_cache = array();
+
 		/**
 		 * Constructor.
 		 *
@@ -488,6 +499,114 @@ if ( ! class_exists( 'WCJ_Product_Addons' ) ) :
 			return true;
 		}
 
+
+		/**
+		 * Returns a safe, stable submitted value for radio/select addon choices.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @param string $label defines the label.
+		 * @param int    $index defines the index.
+		 * @return string
+		 */
+		protected function get_addon_choice_value( $label, $index ) {
+			$plain_label = html_entity_decode( wp_strip_all_tags( (string) $label ), ENT_QUOTES, get_bloginfo( 'charset' ) );
+			$slug        = sanitize_title( $plain_label );
+
+			if ( '' === $slug ) {
+				$slug = 'choice';
+			}
+
+			return 'wcj-pa-' . absint( $index ) . '-' . $slug;
+		}
+
+		/**
+		 * Returns the legacy submitted value used before 8.0.2.
+		 *
+		 * Kept so add-to-cart remains tolerant of older cached forms.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @param string $label defines the label.
+		 * @return string
+		 */
+		protected function get_legacy_addon_choice_value( $label ) {
+			return wp_kses_post( str_replace( ' ', '-', (string) $label ) );
+		}
+
+		/**
+		 * Checks a posted radio/select value against current and legacy choice formats.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @param string $posted_value defines the posted value.
+		 * @param string $label defines the label.
+		 * @param int    $index defines the index.
+		 * @return bool
+		 */
+		protected function is_addon_choice_match( $posted_value, $label, $index ) {
+			$posted_value = (string) $posted_value;
+			$plain_label  = html_entity_decode( wp_strip_all_tags( (string) $label ), ENT_QUOTES, get_bloginfo( 'charset' ) );
+			$choices      = array(
+				$this->get_addon_choice_value( $label, $index ),
+				$this->get_legacy_addon_choice_value( $label ),
+				sanitize_title( $plain_label ),
+				(string) $label,
+			);
+
+			return in_array( $posted_value, $choices, true );
+		}
+
+		/**
+		 * Stores selected addon data in both legacy and structured cart-item formats.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @param array  $cart_item_data defines the cart item data.
+		 * @param array  $addon defines the addon configuration.
+		 * @param string $price_value defines the selected addon price.
+		 * @param string $label_value defines the selected addon label.
+		 * @param string $submitted_value defines the submitted value.
+		 */
+		protected function set_cart_item_addon_selection( &$cart_item_data, $addon, $price_value, $label_value, $submitted_value = '' ) {
+			$cart_item_data[ $addon['price_key'] ] = $price_value;
+			$cart_item_data[ $addon['label_key'] ] = $label_value;
+
+			if ( ! isset( $cart_item_data['wcj_pa_selected_addons'] ) || ! is_array( $cart_item_data['wcj_pa_selected_addons'] ) ) {
+				$cart_item_data['wcj_pa_selected_addons'] = array();
+			}
+
+			$cart_item_data['wcj_pa_selected_addons'][ $addon['price_key'] ] = array(
+				'price_key' => $addon['price_key'],
+				'label_key' => $addon['label_key'],
+				'price'     => $price_value,
+				'label'     => wp_kses_post( $label_value ),
+				'title'     => isset( $addon['title'] ) ? wp_kses_post( $addon['title'] ) : '',
+				'type'      => isset( $addon['type'] ) ? sanitize_key( $addon['type'] ) : '',
+				'value'     => sanitize_text_field( $submitted_value ),
+			);
+		}
+
+		/**
+		 * Reads the selected addon label from structured cart data with legacy fallback.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @param array $item defines the cart/order item data.
+		 * @param array $addon defines the addon configuration.
+		 * @return string
+		 */
+		protected function get_cart_addon_label( $item, $addon ) {
+			if (
+				is_array( $item ) &&
+				isset( $item['wcj_pa_selected_addons'][ $addon['price_key'] ]['label'] )
+			) {
+				return $item['wcj_pa_selected_addons'][ $addon['price_key'] ]['label'];
+			}
+
+			return ( is_array( $item ) && isset( $item[ $addon['label_key'] ] ) ) ? $item[ $addon['label_key'] ] : '';
+		}
+
 		/**
 		 * Get_product_addons.
 		 *
@@ -497,6 +616,13 @@ if ( ! class_exists( 'WCJ_Product_Addons' ) ) :
 		 * @param int $product_id defines the product_id.
 		 */
 		public function get_product_addons( $product_id ) {
+			$product_id = absint( $product_id );
+			$cache_key  = (string) $product_id;
+
+			if ( isset( $this->product_addons_cache[ $cache_key ] ) ) {
+				return $this->product_addons_cache[ $cache_key ];
+			}
+
 			$addons = array();
 			// All Products.
 			$var = get_post_meta( $product_id, 'wcj_product_addons_per_product_qty_' );
@@ -560,6 +686,8 @@ if ( ! class_exists( 'WCJ_Product_Addons' ) ) :
 					}
 				}
 			}
+			$this->product_addons_cache[ $cache_key ] = $addons;
+
 			return $addons;
 		}
 
@@ -622,7 +750,7 @@ if ( ! class_exists( 'WCJ_Product_Addons' ) ) :
 			foreach ( $addons as $addon ) {
 				if ( isset( $values[ $addon['price_key'] ] ) ) {
 					wc_add_order_item_meta( $item_id, '_' . $addon['price_key'], $this->maybe_convert_currency( $values[ $addon['price_key'] ], $product ) );
-					wc_add_order_item_meta( $item_id, '_' . $addon['label_key'], $values[ $addon['label_key'] ] );
+					wc_add_order_item_meta( $item_id, '_' . $addon['label_key'], $this->get_cart_addon_label( $values, $addon ) );
 				}
 			}
 		}
@@ -654,7 +782,7 @@ if ( ! class_exists( 'WCJ_Product_Addons' ) ) :
 					$addon_price  = ( $is_cart ) ? $this->maybe_convert_currency( $item[ $addon['price_key'] ], $_product ) : $item[ $addon['price_key'] ];
 					$addons_info .= str_replace(
 						array( '%addon_label%', '%addon_price%', '%addon_title%' ),
-						array( $item[ $addon['label_key'] ], wc_price( wcj_get_product_display_price( $_product, $addon_price ) ), $addon['title'] ),
+						array( $this->get_cart_addon_label( $item, $addon ), wc_price( wcj_get_product_display_price( $_product, $addon_price ) ), $addon['title'] ),
 						$item_format
 					);
 				}
@@ -779,19 +907,18 @@ if ( ! class_exists( 'WCJ_Product_Addons' ) ) :
 				) {
 					$checkbox_key = isset( $_POST[ $addon['checkbox_key'] ] ) ? sanitize_text_field( wp_unslash( $_POST[ $addon['checkbox_key'] ] ) ) : ( ! empty( $addon['default'] ) ? sanitize_text_field( wp_unslash( $addon['default'] ) ) : null );
 					if ( ( 'checkbox' === $addon['type'] || '' === $addon['type'] ) || ( 'text' === $addon['type'] && '' !== $checkbox_key ) ) {
-						$cart_item_data[ $addon['price_key'] ] = $price_value;
-						$cart_item_data[ $addon['label_key'] ] = $addon['label_value'];
+						$label_value = $addon['label_value'];
 						if ( 'text' === $addon['type'] ) {
-							$cart_item_data[ $addon['label_key'] ] .= ' (' . $checkbox_key . ')';
+							$label_value .= ' (' . $checkbox_key . ')';
 						}
+						$this->set_cart_item_addon_selection( $cart_item_data, $addon, $price_value, $label_value, $checkbox_key );
 					} elseif ( 'radio' === $addon['type'] || 'select' === $addon['type'] ) {
 						$prices = $this->clean_and_explode( PHP_EOL, $price_value );
 						$labels = $this->clean_and_explode( PHP_EOL, $addon['label_value'] );
 						if ( count( $labels ) === count( $prices ) ) {
 							foreach ( $labels as $i => $label ) {
-								if ( wp_kses_post( str_replace( ' ', '-', $label ) ) === $checkbox_key ) {
-									$cart_item_data[ $addon['price_key'] ] = $prices[ $i ];
-									$cart_item_data[ $addon['label_key'] ] = $labels[ $i ];
+								if ( $this->is_addon_choice_match( $checkbox_key, $label, $i ) ) {
+									$this->set_cart_item_addon_selection( $cart_item_data, $addon, $prices[ $i ], $labels[ $i ], $checkbox_key );
 									break;
 								}
 							}
@@ -879,13 +1006,15 @@ if ( ! class_exists( 'WCJ_Product_Addons' ) ) :
 							$select_options = '';
 						}
 						foreach ( $labels as $i => $label ) {
-							$label               = wp_kses_post( str_replace( ' ', '-', $label ) );
+							$choice_value        = $this->get_addon_choice_value( $label, $i );
+							$choice_id           = sanitize_html_class( $choice_value );
 							$is_checked          = '';
 							$checked_or_selected = ( 'radio' === $addon['type'] ? ' checked' : ' selected' );
 							if ( $wpnonce && isset( $_POST[ $addon['checkbox_key'] ] ) ) {
-								$is_checked = ( $label === $_POST[ $addon['checkbox_key'] ] ) ? $checked_or_selected : '';
+								$posted_choice = sanitize_text_field( wp_unslash( $_POST[ $addon['checkbox_key'] ] ) );
+								$is_checked    = $this->is_addon_choice_match( $posted_choice, $label, $i ) ? $checked_or_selected : '';
 							} elseif ( '' !== $addon['default'] ) {
-								$is_checked = ( sanitize_title( $addon['default'] ) === $label ) ? $checked_or_selected : '';
+								$is_checked = $this->is_addon_choice_match( $addon['default'], $label, $i ) ? $checked_or_selected : '';
 							}
 							if ( 'radio' === $addon['type'] ) {
 								$maybe_tooltip = ( isset( $tooltips[ $i ] ) && '' !== $tooltips[ $i ] ) ?
@@ -893,8 +1022,8 @@ if ( ! class_exists( 'WCJ_Product_Addons' ) ) :
 								'';
 								$html         .= wcj_handle_replacements(
 									array(
-										'%addon_input%'   => '<input type="radio" id="' . $addon['checkbox_key'] . '-' . $label . '" class="' . $addon['class'] . '" name="' . $addon['checkbox_key'] . '" value="' . $label . '"' . $is_checked . $is_required . '>',
-										'%addon_id%'      => $addon['checkbox_key'] . '-' . $label,
+										'%addon_input%'   => '<input type="radio" id="' . esc_attr( $addon['checkbox_key'] . '-' . $choice_id ) . '" class="' . esc_attr( $addon['class'] ) . '" name="' . esc_attr( $addon['checkbox_key'] ) . '" value="' . esc_attr( $choice_value ) . '"' . $is_checked . $is_required . '>',
+										'%addon_id%'      => $addon['checkbox_key'] . '-' . $choice_id,
 										'%addon_label%'   => $labels[ $i ],
 										'%addon_price%'   => $this->format_addon_price( $prices[ $i ], $_product ),
 										'%addon_tooltip%' => $maybe_tooltip,
@@ -912,7 +1041,7 @@ if ( ! class_exists( 'WCJ_Product_Addons' ) ) :
 									),
 									wcj_get_option( 'wcj_product_addons_template_type_select_option', '%addon_label% (%addon_price%)' )
 								);
-								$select_options .= '<option value="' . $label . '"' . $is_checked . '>' . $select_option . '</option>';
+								$select_options .= '<option value="' . esc_attr( $choice_value ) . '"' . $is_checked . '>' . $select_option . '</option>';
 							}
 						}
 						if ( 'select' === $addon['type'] ) {

--- a/includes/core/wcj-loader.php
+++ b/includes/core/wcj-loader.php
@@ -54,6 +54,8 @@ require_once WCJ_FREE_PLUGIN_PATH . '/includes/wcj-quick-start-presets.php';
 // Quick Start Admin UI.
 if ( is_admin() ) {
 	require_once WCJ_FREE_PLUGIN_PATH . '/includes/admin/wcj-quick-start-admin.php';
+	// Compatibility Status.
+	require_once WCJ_FREE_PLUGIN_PATH . '/includes/class-wcj-compatibility-status.php';
 }
 
 // Classes.

--- a/includes/input-fields/class-wcj-product-input-fields-core.php
+++ b/includes/input-fields/class-wcj-product-input-fields-core.php
@@ -582,9 +582,10 @@ if ( ! class_exists( 'WCJ_Product_Input_Fields_Core' ) ) :
 				}
 
 				if ( 'file' === $type && isset( $_FILES[ $field_name ] ) && '' !== $_FILES[ $field_name ]['name'] ) {
-					$file_name = sanitize_file_name( wp_unslash( $_FILES[ $field_name ]['name'] ) );
-					$validate  = wp_check_filetype( $file_name );
-					if ( empty( $validate['type'] ) ) {
+					$file_name      = sanitize_file_name( wp_unslash( $_FILES[ $field_name ]['name'] ) );
+					$temp_file_name = isset( $_FILES[ $field_name ]['tmp_name'] ) ? sanitize_text_field( wp_unslash( $_FILES[ $field_name ]['tmp_name'] ) ) : '';
+					$validate       = wp_check_filetype_and_ext( $temp_file_name, $file_name );
+					if ( empty( $validate['type'] ) || empty( $validate['ext'] ) ) {
 						$passed = false;
 						wc_add_notice( __( 'File type is not allowed.', 'woocommerce-jetpack' ), 'error' );
 					}
@@ -911,7 +912,12 @@ if ( ! class_exists( 'WCJ_Product_Input_Fields_Core' ) ) :
 						isset( $_FILES[ $value_name ]['error'], $_FILES[ $value_name ]['tmp_name'] ) &&
 						UPLOAD_ERR_OK === $_FILES[ $value_name ]['error']
 					) {
-						$temp_file_name                = sanitize_text_field( wp_unslash( $_FILES[ $value_name ]['tmp_name'] ) );
+						$temp_file_name = sanitize_text_field( wp_unslash( $_FILES[ $value_name ]['tmp_name'] ) );
+						$file_name      = isset( $_FILES[ $value_name ]['name'] ) ? sanitize_file_name( wp_unslash( $_FILES[ $value_name ]['name'] ) ) : '';
+						$validate       = wp_check_filetype_and_ext( $temp_file_name, $file_name );
+						if ( empty( $validate['type'] ) || empty( $validate['ext'] ) ) {
+							continue;
+						}
 						$cart_item_data[ $value_name ] = array_map( 'sanitize_text_field', wp_unslash( $_FILES[ $value_name ] ) );
 						$tmp_dest_file                 = tempnam( wcj_get_wcj_uploads_dir( 'temp' ), 'wcj' );
 						if ( $tmp_dest_file && move_uploaded_file( $temp_file_name, $tmp_dest_file ) ) {

--- a/includes/shortcodes/class-wcj-products-add-form-shortcodes.php
+++ b/includes/shortcodes/class-wcj-products-add-form-shortcodes.php
@@ -116,6 +116,218 @@ if ( ! class_exists( 'WCJ_Products_Add_Form_Shortcodes' ) ) :
 			return $atts;
 		}
 
+
+		/**
+		 * Returns the image MIME types accepted by the Product by User upload form.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @return array
+		 */
+		protected function get_product_by_user_image_mimes() {
+			return apply_filters(
+				'wcj_product_by_user_allowed_image_mime_types',
+				array(
+					'jpg|jpeg|jpe' => 'image/jpeg',
+					'gif'          => 'image/gif',
+					'png'          => 'image/png',
+					'webp'         => 'image/webp',
+					'heic'         => 'image/heic',
+					'heif'         => 'image/heif',
+				)
+			);
+		}
+
+		/**
+		 * Converts PHP upload error codes into safe messages.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @param int $error_code defines the upload error code.
+		 * @return string
+		 */
+		protected function get_product_by_user_upload_error_message( $error_code ) {
+			switch ( (int) $error_code ) {
+				case UPLOAD_ERR_INI_SIZE:
+				case UPLOAD_ERR_FORM_SIZE:
+					return __( 'The uploaded image is too large.', 'woocommerce-jetpack' );
+				case UPLOAD_ERR_PARTIAL:
+					return __( 'The image was only partially uploaded. Please try again.', 'woocommerce-jetpack' );
+				case UPLOAD_ERR_NO_TMP_DIR:
+				case UPLOAD_ERR_CANT_WRITE:
+				case UPLOAD_ERR_EXTENSION:
+					return __( 'The image could not be uploaded. Please try again or contact the store owner.', 'woocommerce-jetpack' );
+				default:
+					return __( 'The uploaded image is not valid.', 'woocommerce-jetpack' );
+			}
+		}
+
+		/**
+		 * Normalizes single and multiple file upload arrays.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @param array $uploaded defines the raw upload array.
+		 * @return array
+		 */
+		protected function normalize_product_by_user_uploads( $uploaded ) {
+			if ( ! is_array( $uploaded ) || ! isset( $uploaded['name'] ) ) {
+				return array();
+			}
+
+			if ( ! is_array( $uploaded['name'] ) ) {
+				return array( $uploaded );
+			}
+
+			$files = array();
+			foreach ( $uploaded['name'] as $index => $name ) {
+				$files[] = array(
+					'name'     => $name,
+					'type'     => isset( $uploaded['type'][ $index ] ) ? $uploaded['type'][ $index ] : '',
+					'tmp_name' => isset( $uploaded['tmp_name'][ $index ] ) ? $uploaded['tmp_name'][ $index ] : '',
+					'error'    => isset( $uploaded['error'][ $index ] ) ? $uploaded['error'][ $index ] : UPLOAD_ERR_NO_FILE,
+					'size'     => isset( $uploaded['size'][ $index ] ) ? $uploaded['size'][ $index ] : 0,
+				);
+			}
+
+			return $files;
+		}
+
+		/**
+		 * Validates a Product by User image upload before it can be moved to uploads.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @param array $file defines the uploaded file array.
+		 * @return array|WP_Error
+		 */
+		protected function validate_product_by_user_image_upload( $file ) {
+			if ( ! is_array( $file ) || ! isset( $file['error'], $file['name'], $file['tmp_name'], $file['size'] ) ) {
+				return new WP_Error( 'wcj_product_by_user_image_invalid', __( 'The uploaded image is not valid.', 'woocommerce-jetpack' ) );
+			}
+
+			$error_code = (int) $file['error'];
+			if ( UPLOAD_ERR_OK !== $error_code ) {
+				return new WP_Error( 'wcj_product_by_user_image_upload_error', $this->get_product_by_user_upload_error_message( $error_code ) );
+			}
+
+			$file_name = sanitize_file_name( wp_unslash( $file['name'] ) );
+			$tmp_name  = is_string( $file['tmp_name'] ) ? $file['tmp_name'] : '';
+			$file_size = (int) $file['size'];
+
+			if ( '' === $file_name || '' === $tmp_name || $file_size <= 0 ) {
+				return new WP_Error( 'wcj_product_by_user_image_empty', __( 'The uploaded image is empty or invalid.', 'woocommerce-jetpack' ) );
+			}
+
+			if ( ! is_uploaded_file( $tmp_name ) ) {
+				return new WP_Error( 'wcj_product_by_user_image_not_uploaded', __( 'The uploaded image could not be verified.', 'woocommerce-jetpack' ) );
+			}
+
+			$file_type = wp_check_filetype_and_ext( $tmp_name, $file_name, $this->get_product_by_user_image_mimes() );
+			if ( empty( $file_type['ext'] ) || empty( $file_type['type'] ) || 0 !== strpos( $file_type['type'], 'image/' ) ) {
+				return new WP_Error( 'wcj_product_by_user_image_type_blocked', __( 'File type is not allowed. Please upload a JPG, PNG, GIF, WEBP, HEIC, or HEIF image.', 'woocommerce-jetpack' ) );
+			}
+
+			if ( ! empty( $file_type['proper_filename'] ) ) {
+				$file_name = sanitize_file_name( $file_type['proper_filename'] );
+			}
+
+			return array(
+				'name'     => $file_name,
+				'type'     => sanitize_mime_type( $file_type['type'] ),
+				'tmp_name' => $tmp_name,
+				'error'    => UPLOAD_ERR_OK,
+				'size'     => $file_size,
+			);
+		}
+
+		/**
+		 * Gets validated image uploads for the Product by User form.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @param string $field_name defines the file input name.
+		 * @return array
+		 */
+		protected function get_validated_product_by_user_image_uploads( $field_name ) {
+			$results = array(
+				'files'  => array(),
+				'errors' => array(),
+			);
+
+			if ( empty( $_FILES ) || ! isset( $_FILES[ $field_name ] ) || ! is_array( $_FILES[ $field_name ] ) ) {
+				return $results;
+			}
+
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- File arrays are normalized and validated below.
+			$files = $this->normalize_product_by_user_uploads( $_FILES[ $field_name ] );
+			foreach ( $files as $file ) {
+				$error_code = isset( $file['error'] ) ? (int) $file['error'] : UPLOAD_ERR_NO_FILE;
+				$file_name  = isset( $file['name'] ) ? sanitize_file_name( wp_unslash( $file['name'] ) ) : '';
+
+				if ( UPLOAD_ERR_NO_FILE === $error_code || '' === $file_name ) {
+					continue;
+				}
+
+				$validated_file = $this->validate_product_by_user_image_upload( $file );
+				if ( is_wp_error( $validated_file ) ) {
+					$results['errors'][] = $validated_file->get_error_message();
+					continue;
+				}
+
+				$results['files'][] = $validated_file;
+			}
+
+			return $results;
+		}
+
+		/**
+		 * Attaches a validated Product by User image upload to a product.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @param string $field_name defines the file input name.
+		 * @param array  $file defines the validated uploaded file.
+		 * @param int    $product_id defines the product ID.
+		 * @return int|WP_Error
+		 */
+		protected function attach_product_by_user_image_upload( $field_name, $file, $product_id ) {
+			if ( ! is_array( $file ) || empty( $file['tmp_name'] ) ) {
+				return new WP_Error( 'wcj_product_by_user_image_missing', __( 'The uploaded image is not valid.', 'woocommerce-jetpack' ) );
+			}
+
+			$validated_file = $this->validate_product_by_user_image_upload( $file );
+			if ( is_wp_error( $validated_file ) ) {
+				return $validated_file;
+			}
+
+			require_once ABSPATH . 'wp-admin/includes/image.php';
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			require_once ABSPATH . 'wp-admin/includes/media.php';
+
+			$had_original_file = isset( $_FILES[ $field_name ] );
+			$original_file     = $had_original_file ? $_FILES[ $field_name ] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$_FILES[ $field_name ] = $validated_file;
+
+			$attachment_id = media_handle_upload(
+				$field_name,
+				$product_id,
+				array(),
+				array(
+					'test_form' => false,
+					'mimes'     => $this->get_product_by_user_image_mimes(),
+				)
+			);
+
+			if ( $had_original_file ) {
+				$_FILES[ $field_name ] = $original_file;
+			} else {
+				unset( $_FILES[ $field_name ] );
+			}
+
+			return $attachment_id;
+		}
+
 		/**
 		 * Wc_add_new_product.
 		 *
@@ -170,27 +382,11 @@ if ( ! class_exists( 'WCJ_Products_Add_Form_Shortcodes' ) ) :
 				}
 
 				// Image.
-				if ( '' !== $args['image'] && '' !== $args['image']['tmp_name'] ) {
-					$upload_dir = wp_upload_dir();
-					$filename   = $args['image']['name'];
-					$file       = ( wp_mkdir_p( $upload_dir['path'] ) ) ? $upload_dir['path'] : $upload_dir['basedir'];
-					$file      .= '/' . $filename;
-
-					move_uploaded_file( $args['image']['tmp_name'], $file );
-
-					$wp_filetype = wp_check_filetype( $filename, null );
-					$attachment  = array(
-						'post_mime_type' => $wp_filetype['type'],
-						'post_title'     => sanitize_file_name( $filename ),
-						'post_content'   => '',
-						'post_status'    => 'inherit',
-					);
-					$attach_id   = wp_insert_attachment( $attachment, $file, $product_id );
-					require_once ABSPATH . 'wp-admin/includes/image.php';
-					$attach_data = wp_generate_attachment_metadata( $attach_id, $file );
-					wp_update_attachment_metadata( $attach_id, $attach_data );
-
-					set_post_thumbnail( $product_id, $attach_id );
+				if ( ! empty( $args['image'] ) && is_array( $args['image'] ) && ! empty( $args['image']['tmp_name'] ) ) {
+					$attach_id = $this->attach_product_by_user_image_upload( 'wcj_add_new_product_image', $args['image'], $product_id );
+					if ( ! is_wp_error( $attach_id ) && $attach_id ) {
+						set_post_thumbnail( $product_id, $attach_id );
+					}
 				}
 
 				wp_update_post(
@@ -218,6 +414,14 @@ if ( ! class_exists( 'WCJ_Products_Add_Form_Shortcodes' ) ) :
 				$errors .= '<li>' . __( 'Title is required!', 'woocommerce-jetpack' ) . '</li>';
 			}
 
+			foreach ( array( 'image_upload_errors', 'image_gallery_upload_errors' ) as $upload_error_key ) {
+				if ( ! empty( $args[ $upload_error_key ] ) && is_array( $args[ $upload_error_key ] ) ) {
+					foreach ( $args[ $upload_error_key ] as $upload_error ) {
+						$errors .= '<li>' . esc_html( $upload_error ) . '</li>';
+					}
+				}
+			}
+
 			if ( 'yes' === wcj_get_option( 'wcj_product_by_user_require_unique_title', 'no' ) && 0 === $shortcode_atts['product_id'] ) {
 				if ( ! function_exists( 'post_exists' ) ) {
 					require_once ABSPATH . 'wp-admin/includes/post.php';
@@ -243,7 +447,7 @@ if ( ! class_exists( 'WCJ_Products_Add_Form_Shortcodes' ) ) :
 			foreach ( $fields as $field_id => $field_desc ) {
 				if ( 'yes' === $shortcode_atts[ $field_id . '_enabled' ] && 'yes' === $shortcode_atts[ $field_id . '_required' ] ) {
 					$is_missing = false;
-					if ( 'image' === $field_id && ( '' === $args[ $field_id ] || ! isset( $args[ $field_id ]['tmp_name'] ) || '' === $args[ $field_id ]['tmp_name'] ) ) {
+					if ( 'image' === $field_id && empty( $args['image_upload_errors'] ) && ( '' === $args[ $field_id ] || ! isset( $args[ $field_id ]['tmp_name'] ) || '' === $args[ $field_id ]['tmp_name'] ) ) {
 						$is_missing = true;
 					} elseif ( empty( $args[ $field_id ] ) ) {
 						$is_missing = true;
@@ -259,29 +463,20 @@ if ( ! class_exists( 'WCJ_Products_Add_Form_Shortcodes' ) ) :
 				$errors .= '<li>' . __( 'Sale price must be less than the regular price!', 'woocommerce-jetpack' ) . '</li>';
 			}
 
-			$product_image_name = isset( $args['image']['name'] ) ? sanitize_text_field( wp_unslash( $args['image']['name'] ) ) : '';
-			$gallery_images     = isset( $args['image_gallery']['name'] ) ? array_map( 'sanitize_text_field', wp_unslash( $args['image_gallery']['name'] ) ) : array();
-
-			$allowed_types = array( '.jpg', '.jpeg', '.png', '.webp', '.heic', '.heif', '.gif' ); // Allowed File types by WordPress https://wordpress.com/support/accepted-filetypes/.
-
-			// Verify and restrict Product Image.
-			if ( isset( $product_image_name ) && '' !== $product_image_name ) {
-				$file_type = '.' . pathinfo( $product_image_name, PATHINFO_EXTENSION );
-				if ( ! in_array( $file_type, $allowed_types, true ) ) {
-					$errors .= '<li>' . __( 'Sorry, only JPG, JPEG, PNG, WEBP, HEIC, HEIF and GIF files are allowed', 'woocommerce-jetpack' ) . '</li>';
+			// Verify actual Product by User image uploads before they can be moved to public uploads.
+			if ( ! empty( $args['image'] ) && is_array( $args['image'] ) ) {
+				$product_image = $this->validate_product_by_user_image_upload( $args['image'] );
+				if ( is_wp_error( $product_image ) ) {
+					$errors .= '<li>' . esc_html( $product_image->get_error_message() ) . '</li>';
 				}
 			}
-			// Verify and restrict Gallery Image.
-			if ( isset( $gallery_images ) && ! empty( array_filter( $gallery_images ) ) ) {
-				$error_encountered = false; // Flag variable to track if an error has been encountered.
-				foreach ( $gallery_images as $gallery_image_name ) {
-					$gallery_file_type = '.' . pathinfo( $gallery_image_name, PATHINFO_EXTENSION );
-					if ( ! in_array( $gallery_file_type, $allowed_types, true ) ) {
-						if ( ! $error_encountered && ! $errors ) {
 
-							$errors           .= '<li>' . __( 'Sorry, only JPG, JPEG, PNG, WEBP, HEIC, HEIF and GIF files are allowed', 'woocommerce-jetpack' ) . '</li>';
-							$error_encountered = true; // Set the flag to true to indicate error has been encountered.
-						}
+			if ( ! empty( $args['image_gallery'] ) && is_array( $args['image_gallery'] ) ) {
+				foreach ( $args['image_gallery'] as $gallery_image ) {
+					$validated_gallery_image = $this->validate_product_by_user_image_upload( $gallery_image );
+					if ( is_wp_error( $validated_gallery_image ) ) {
+						$errors .= '<li>' . esc_html( $validated_gallery_image->get_error_message() ) . '</li>';
+						break;
 					}
 				}
 			}
@@ -385,25 +580,20 @@ if ( ! class_exists( 'WCJ_Products_Add_Form_Shortcodes' ) ) :
 			$input_fields_html = '';
 			$footer_html       = '';
 
-			$image = '';
+			$image                       = '';
+			$image_upload_errors         = array();
+			$image_gallery               = array();
+			$image_gallery_upload_errors = array();
+			$is_submitting_product       = $wpnonce && isset( $_REQUEST['wcj_add_new_product'] );
 
-			if ( ! empty( $_FILES ) && isset( $_FILES['wcj_add_new_product_image'] ) && is_array( $_FILES['wcj_add_new_product_image'] ) ) {
+			if ( $is_submitting_product ) {
+				$product_image_upload = $this->get_validated_product_by_user_image_uploads( 'wcj_add_new_product_image' );
+				$image                = ! empty( $product_image_upload['files'] ) ? reset( $product_image_upload['files'] ) : '';
+				$image_upload_errors  = $product_image_upload['errors'];
 
-				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- File array is validated below.
-				$file = $_FILES['wcj_add_new_product_image'];
-
-				if (
-					isset( $file['error'], $file['name'], $file['type'], $file['tmp_name'], $file['size'] ) &&
-					UPLOAD_ERR_OK === (int) $file['error']
-				) {
-					$image = array(
-						'name'     => sanitize_file_name( wp_unslash( $file['name'] ) ),
-						'type'     => sanitize_mime_type( $file['type'] ),
-						'tmp_name' => $file['tmp_name'], // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-						'error'    => (int) $file['error'],
-						'size'     => (int) $file['size'],
-					);
-				}
+				$gallery_image_upload         = $this->get_validated_product_by_user_image_uploads( 'wcj_add_new_product_gallery_image' );
+				$image_gallery                = $gallery_image_upload['files'];
+				$image_gallery_upload_errors = $gallery_image_upload['errors'];
 			}
 
 			$args = array(
@@ -415,25 +605,13 @@ if ( ! class_exists( 'WCJ_Products_Add_Form_Shortcodes' ) ) :
 				'external_url'  => isset( $_REQUEST['wcj_add_new_product_external_url'] ) ? esc_url( sanitize_text_field( wp_unslash( $_REQUEST['wcj_add_new_product_external_url'] ) ) ) : '',
 				'cats'          => isset( $_REQUEST['wcj_add_new_product_cats'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_REQUEST['wcj_add_new_product_cats'] ) ) : array(),
 				'image'         => $image,
+				'image_upload_errors' => $image_upload_errors,
+				'image_gallery' => $image_gallery,
+				'image_gallery_upload_errors' => $image_gallery_upload_errors,
 				'category'      => isset( $_POST['wcj_add_new_product_category'] ) ? sanitize_text_field( wp_unslash( $_POST['wcj_add_new_product_category'] ) ) : '',
 				'tags'          => isset( $_POST['wcj_add_new_product_tags'] ) ? sanitize_text_field( wp_unslash( $_POST['wcj_add_new_product_tags'] ) ) : '',
 				'type'          => isset( $_POST['wcj_add_new_product_type'] ) ? sanitize_text_field( wp_unslash( $_POST['wcj_add_new_product_type'] ) ) : 'simple',
 			);
-			if ( '' !== $args['image'] ) {
-				$file_name = $args['image']['name'];
-				$file_type = $args['image']['type'];
-				$file_tmp  = $args['image']['tmp_name'];
-				$file_err  = $args['image']['error'];
-				$file_size = $args['image']['size'];
-
-				$upload_dir = wp_upload_dir();
-				$file       = $upload_dir['path'] . '/' . $file_name;
-				if ( move_uploaded_file( $file_tmp, $file ) ) {
-					$args['image'] = $file;
-				} else {
-					$args['image'] = '';
-				}
-			}
 			for ( $i = 1; $i <= $this->the_atts['custom_taxonomies_total']; $i++ ) {
 				$param_id                        = 'wcj_add_new_product_custom_taxonomy_' . $i;
 				$args[ 'custom_taxonomy_' . $i ] = isset( $_REQUEST[ $param_id ] ) ? sanitize_text_field( wp_unslash( $_REQUEST[ $param_id ] ) ) : array();

--- a/includes/shortcodes/class-wcj-products-add-form-shortcodes.php
+++ b/includes/shortcodes/class-wcj-products-add-form-shortcodes.php
@@ -194,6 +194,33 @@ if ( ! class_exists( 'WCJ_Products_Add_Form_Shortcodes' ) ) :
 		}
 
 		/**
+		 * Checks whether a Product by User file field contains a real upload attempt.
+		 *
+		 * @version 8.0.2
+		 * @since   8.0.2
+		 * @param string $field_name defines the file input name.
+		 * @return bool
+		 */
+		protected function has_product_by_user_uploaded_file( $field_name ) {
+			if ( empty( $_FILES ) || ! isset( $_FILES[ $field_name ] ) || ! is_array( $_FILES[ $field_name ] ) ) {
+				return false;
+			}
+
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- File arrays are only inspected for upload presence here.
+			$files = $this->normalize_product_by_user_uploads( $_FILES[ $field_name ] );
+			foreach ( $files as $file ) {
+				$error_code = isset( $file['error'] ) ? (int) $file['error'] : UPLOAD_ERR_NO_FILE;
+				$file_name  = isset( $file['name'] ) ? sanitize_file_name( wp_unslash( $file['name'] ) ) : '';
+
+				if ( UPLOAD_ERR_NO_FILE !== $error_code || '' !== $file_name ) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		/**
 		 * Validates a Product by User image upload before it can be moved to uploads.
 		 *
 		 * @version 8.0.2
@@ -587,13 +614,21 @@ if ( ! class_exists( 'WCJ_Products_Add_Form_Shortcodes' ) ) :
 			$is_submitting_product       = $wpnonce && isset( $_REQUEST['wcj_add_new_product'] );
 
 			if ( $is_submitting_product ) {
-				$product_image_upload = $this->get_validated_product_by_user_image_uploads( 'wcj_add_new_product_image' );
-				$image                = ! empty( $product_image_upload['files'] ) ? reset( $product_image_upload['files'] ) : '';
-				$image_upload_errors  = $product_image_upload['errors'];
+				if ( 'yes' === $atts['image_enabled'] ) {
+					$product_image_upload = $this->get_validated_product_by_user_image_uploads( 'wcj_add_new_product_image' );
+					$image                = ! empty( $product_image_upload['files'] ) ? reset( $product_image_upload['files'] ) : '';
+					$image_upload_errors  = $product_image_upload['errors'];
+				} elseif ( $this->has_product_by_user_uploaded_file( 'wcj_add_new_product_image' ) ) {
+					$image_upload_errors[] = __( 'Image uploads are not enabled for this form.', 'woocommerce-jetpack' );
+				}
 
-				$gallery_image_upload         = $this->get_validated_product_by_user_image_uploads( 'wcj_add_new_product_gallery_image' );
-				$image_gallery                = $gallery_image_upload['files'];
-				$image_gallery_upload_errors = $gallery_image_upload['errors'];
+				if ( 'yes' === $atts['image_gallery_enabled'] ) {
+					$gallery_image_upload         = $this->get_validated_product_by_user_image_uploads( 'wcj_add_new_product_gallery_image' );
+					$image_gallery                = $gallery_image_upload['files'];
+					$image_gallery_upload_errors = $gallery_image_upload['errors'];
+				} elseif ( $this->has_product_by_user_uploaded_file( 'wcj_add_new_product_gallery_image' ) ) {
+					$image_gallery_upload_errors[] = __( 'Image gallery uploads are not enabled for this form.', 'woocommerce-jetpack' );
+				}
 			}
 
 			$args = array(

--- a/readme.txt
+++ b/readme.txt
@@ -348,7 +348,7 @@ No. Onboarding analytics are local-only (apply/undo/mode views) to improve the e
 == Changelog ==
 
 = 8.0.2 - 15/06/2026 =
-* Security - Hardened Product by User image uploads so customer-submitted product images are validated as real allowed image files before they can be moved into uploads, and Free keeps paid image upload fields disabled even if a request is manually crafted.
+* Security - Hardened Product by User media upload handling and Free tier upload boundaries.
 * Security hardening - Strengthened related customer upload validation in Checkout Files Upload and Product Input Fields.
 * Continuous improvement - Free stores get safer Product Addons selection handling: radio/select choices now use stable submitted values while older cached forms remain compatible.
 * Checkout confidence - Booster now shows admin-only compatibility status when active checkout modules need Classic Checkout, Checkout Blocks staging, or HPOS review.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pluggabl, ronyp, gravid7
 Donate link: https://booster.io/
 Tags: woocommerce, abandoned cart, cart recovery, swatches, woocommerce pdf invoices, variation swatches, woocommerce multi currency, woocommerce dynamic pricing, woocommerce checkout fields, woocommerce product addons, woocommerce product feed, currency switcher
 Requires at least: 5.8
-Tested up to: 6.9.4
+Tested up to: 7.0
 Requires PHP: 7.2
 Stable tag: 8.0.2
 License: GNU General Public License v3.0
@@ -348,6 +348,8 @@ No. Onboarding analytics are local-only (apply/undo/mode views) to improve the e
 == Changelog ==
 
 = 8.0.2 - 15/06/2026 =
+* Security - Hardened Product by User image uploads so customer-submitted product images are validated as real allowed image files before they can be moved into uploads.
+* Security hardening - Strengthened related customer upload validation in Checkout Files Upload and Product Input Fields.
 * Continuous improvement - Free stores get safer Product Addons selection handling: radio/select choices now use stable submitted values while older cached forms remain compatible.
 * Checkout confidence - Booster now shows admin-only compatibility status when active checkout modules need Classic Checkout, Checkout Blocks staging, or HPOS review.
 * Reliability - Order Numbers and PDF Invoicing now prefer WooCommerce order APIs for maintained order meta reads/writes, with legacy fallbacks for older stores.

--- a/readme.txt
+++ b/readme.txt
@@ -348,7 +348,7 @@ No. Onboarding analytics are local-only (apply/undo/mode views) to improve the e
 == Changelog ==
 
 = 8.0.2 - 15/06/2026 =
-* Security - Hardened Product by User image uploads so customer-submitted product images are validated as real allowed image files before they can be moved into uploads.
+* Security - Hardened Product by User image uploads so customer-submitted product images are validated as real allowed image files before they can be moved into uploads, and Free keeps paid image upload fields disabled even if a request is manually crafted.
 * Security hardening - Strengthened related customer upload validation in Checkout Files Upload and Product Input Fields.
 * Continuous improvement - Free stores get safer Product Addons selection handling: radio/select choices now use stable submitted values while older cached forms remain compatible.
 * Checkout confidence - Booster now shows admin-only compatibility status when active checkout modules need Classic Checkout, Checkout Blocks staging, or HPOS review.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: woocommerce, abandoned cart, cart recovery, swatches, woocommerce pdf invo
 Requires at least: 5.8
 Tested up to: 6.9.4
 Requires PHP: 7.2
-Stable tag: 8.0.1
+Stable tag: 8.0.2
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -346,6 +346,13 @@ No. Onboarding analytics are local-only (apply/undo/mode views) to improve the e
 * For support please visit the [Plugin Support Forum](https://wordpress.org/support/plugin/woocommerce-jetpack/).
 
 == Changelog ==
+
+= 8.0.2 - 15/06/2026 =
+* Continuous improvement - Free stores get safer Product Addons selection handling: radio/select choices now use stable submitted values while older cached forms remain compatible.
+* Checkout confidence - Booster now shows admin-only compatibility status when active checkout modules need Classic Checkout, Checkout Blocks staging, or HPOS review.
+* Reliability - Order Numbers and PDF Invoicing now prefer WooCommerce order APIs for maintained order meta reads/writes, with legacy fallbacks for older stores.
+* Performance - Product Addons settings are cached for the current request to reduce repeated option reads during cart and checkout calculations.
+* Value - The Free feature set keeps its documented limits while receiving maintenance hardening on shared module paths.
 
 = 8.0.1 - 20/05/2026 =
 * Faster Sales Notifications - The recent-purchase popup is now noticeably lighter on busy stores. Booster reuses the most recent result for a short window instead of querying your orders on every popup cycle, cutting database load by roughly 5 in 6 polls.

--- a/version-details.json
+++ b/version-details.json
@@ -1,11 +1,8 @@
 {
-    "0": "= 8.0.1 - 20/05/2026 =",
-    "1": "* Faster Sales Notifications - The recent-purchase popup is now noticeably lighter on busy stores. Booster reuses the most recent result for a short window instead of querying your orders on every popup cycle.",
-    "2": "* Faster checkout - Checkout Fees now calculate once per request instead of rebuilding the fee list every time WooCommerce recalculates the cart.",
-    "3": "* Smoother Checkout Custom Fields - Cart-amount visibility rules no longer recalculate the cart for each field; the total is reused across all visibility checks in a single page load.",
-    "4": "* Fix - Multiple checkout fees: fees beyond the first now respect their own enabled/disabled setting when several fees are configured.",
-    "5": "* Fix - PHP 8.x compatibility: Checkout Fees priority sorting now uses a strict integer comparator that works correctly on modern PHP.",
-    "6": "* Security - Hardened a public AJAX endpoint in the Price by User Role module to require a valid security token.",
-    "7": "* WooCommerce 10.7.0 Tested",
-    "8": "* WordPress 6.9.4 Tested"
+    "0": "= 8.0.2 - 15/06/2026 =",
+    "1": "* Continuous improvement - Free stores get safer Product Addons selection handling with stable submitted values and compatibility for older cached forms.",
+    "2": "* Checkout confidence - Added admin-only compatibility status for active checkout modules that need Classic Checkout, Checkout Blocks staging, or HPOS review.",
+    "3": "* Reliability - Order Numbers and PDF Invoicing now prefer WooCommerce order APIs for maintained order meta reads/writes, with legacy fallbacks.",
+    "4": "* Performance - Product Addons settings are cached for the current request to reduce repeated option reads during cart and checkout calculations.",
+    "5": "* Value - The Free feature set keeps its documented limits while receiving maintenance hardening on shared module paths."
 }

--- a/version-details.json
+++ b/version-details.json
@@ -1,8 +1,11 @@
 {
     "0": "= 8.0.2 - 15/06/2026 =",
-    "1": "* Continuous improvement - Free stores get safer Product Addons selection handling with stable submitted values and compatibility for older cached forms.",
-    "2": "* Checkout confidence - Added admin-only compatibility status for active checkout modules that need Classic Checkout, Checkout Blocks staging, or HPOS review.",
-    "3": "* Reliability - Order Numbers and PDF Invoicing now prefer WooCommerce order APIs for maintained order meta reads/writes, with legacy fallbacks.",
-    "4": "* Performance - Product Addons settings are cached for the current request to reduce repeated option reads during cart and checkout calculations.",
-    "5": "* Value - The Free feature set keeps its documented limits while receiving maintenance hardening on shared module paths."
+    "1": "* Security - Hardened Product by User image uploads so customer-submitted product images are validated as real allowed image files before they can be moved into uploads.",
+    "2": "* Security hardening - Strengthened related customer upload validation in Checkout Files Upload and Product Input Fields.",
+    "3": "* Continuous improvement - Free stores get safer Product Addons selection handling with stable submitted values and compatibility for older cached forms.",
+    "4": "* Checkout confidence - Added admin-only compatibility status for active checkout modules that need Classic Checkout, Checkout Blocks staging, or HPOS review.",
+    "5": "* Reliability - Order Numbers and PDF Invoicing now prefer WooCommerce order APIs for maintained order meta reads/writes, with legacy fallbacks.",
+    "6": "* Performance - Product Addons settings are cached for the current request to reduce repeated option reads during cart and checkout calculations.",
+    "7": "* Value - The Free feature set keeps its documented limits while receiving maintenance hardening on shared module paths.",
+    "8": "* WordPress 7.0 Tested"
 }

--- a/woocommerce-jetpack.php
+++ b/woocommerce-jetpack.php
@@ -4,7 +4,7 @@
  * Requires Plugins: woocommerce
  * Plugin URI: https://booster.io
  * Description: Supercharge your WooCommerce site with these awesome powerful features.
- * Version: 8.0.1
+ * Version: 8.0.2
  * Author: Pluggabl LLC
  * Author URI: https://booster.io
  * Text Domain: woocommerce-jetpack
@@ -72,7 +72,7 @@ if ( ! class_exists( 'WC_Jetpack' ) ) :
 		 *
 		 * @var string
 		 */
-		public $version = '8.0.1';
+		public $version = '8.0.2';
 
 		/**
 		 * Singleton instance.


### PR DESCRIPTION
## Summary
- Bump Free package metadata to 8.0.2 for the June 15, 2026 maintenance release target.
- Add admin-only compatibility status guidance for active Checkout Blocks / Classic Checkout / HPOS-sensitive Booster modules.
- Harden shared maintenance paths: Product Addons stable radio/select submitted values and structured cart data; Order Numbers and PDF Invoicing prefer WooCommerce order APIs with legacy fallbacks.
- Update readme/version details with tier-specific release wording.

## Tier boundary
Keeps Free module limits in place; docs emphasize continuous improvement, value, and shared-path hardening without enabling paid-only controls.

## Validation
- php -l on touched PHP files.
- git diff --check.
- Docker WordPress runtime checks with WooCommerce 10.6.2 / PHP 8.2: activation plus version, Product Addons integrated add-to-cart data, Order Numbers meta helper, PDF Invoicing customer helper, and compatibility status checks.
- Runtime PASS: Free, Elite, and Plus each passed their 8.0.2 eval-file checks; no fatal/parse/uncaught errors found in debug-log fatal scan.