### PR TITLE
Booster 8.1.0: Checkout Blocks, HPOS, performance, and reliability

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,16 @@
 == Changelog ==
 
+= 8.1.0 - 15/07/2026 =
+* Checkout Blocks compatibility - Added supported Checkout Custom Fields to Blocks checkout with server-side validation, order saving, and module-specific product, category, and cart visibility on supported WooCommerce versions.
+* Checkout Blocks compatibility - Kept textarea fields, checkout-field-conditional fees, and checkout file collection on their safe Classic Checkout or post-order paths instead of overstating Blocks support.
+* HPOS compatibility - Modernized Order Numbers, Checkout Files Upload, PDF Invoicing, Checkout Custom Fields, Product Addons, and Product Input Fields to use WooCommerce order and order-item APIs in active order workflows.
+* Performance - Reused normalized fee, gateway, input-field, invoice, product, and category configuration within each request to reduce repeated work in cart, checkout, order, and PDF paths.
+* Reliability - Preserved conditional fees when a guest creates an account during Classic Checkout, prevented duplicate order-item writes, and strengthened fallbacks around checkout and order data.
+* Admin experience - Expanded module-level Checkout Blocks and HPOS status guidance with clear supported, partial, and Classic-only boundaries.
+* Tier-specific value - Improved the existing Free field, fee, upload, order-number, invoice, add-on, and input-field capabilities without enabling paid counts or premium controls.
+* Security hardening - Strengthened validation and request handling in selected customer-facing workflows.
+
+
 = 8.0.2 - 17/06/2026 =
 * Security - Hardened Product by User media upload handling and Free tier upload boundaries.
 * Security hardening - Strengthened related customer upload validation in Checkout Files Upload and Product Input Fields.

--- a/includes/class-wcj-checkout-custom-fields-blocks.php
+++ b/includes/class-wcj-checkout-custom-fields-blocks.php
@@ -2,27 +2,7 @@
 /**
  * Booster for WooCommerce - Checkout Custom Fields - WooCommerce Blocks Integration
  *
- * Registers Booster checkout custom fields with the WooCommerce Blocks checkout
- * and bridges Blocks-saved data back to Booster meta format so that existing
- * admin display, email, shortcode, and exporter code continues to work.
- *
- * Supported field types on Blocks checkout: text, select, checkbox, radio (as select).
- * Unsupported types (textarea, datepicker, weekpicker, timepicker, number) are
- * silently skipped and continue to work only on classic checkout.
- *
- * Radio fields are automatically converted to select dropdowns on Blocks checkout
- * since the WC Blocks API does not support native radio inputs.
- *
- * Note: Visibility conditions (product/category/cart-amount show/hide) are NOT
- * enforced on Blocks checkout. The WC Blocks additional checkout fields API
- * registers fields globally at plugin init, before cart context is available.
- * Visibility conditions continue to work on classic checkout only.
- *
- * All fields use the 'order' location (additional-information area) on Blocks.
- * The WC Blocks 'address' location duplicates fields across both billing and
- * shipping address groups, which is not the intended Booster section behavior.
- *
- * @version 8.0.0
+ * @version 8.1.0
  * @since   7.12.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -35,61 +15,64 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 
 	/**
-	 * WCJ_Checkout_Custom_Fields_Blocks.
+	 * Checkout Custom Fields integration for the WooCommerce Checkout block.
 	 *
-	 * @version 8.0.0
+	 * Supported field types are text, select, checkbox, and radio (rendered as a
+	 * select). Conditioned fields require WooCommerce 9.9 or later. Earlier
+	 * versions skip conditioned fields instead of displaying them incorrectly.
+	 *
+	 * @version 8.1.0
 	 * @since   7.12.0
 	 */
 	class WCJ_Checkout_Custom_Fields_Blocks {
 
-		/**
-		 * Namespace prefix for WC Blocks field IDs.
-		 *
-		 * @var string
-		 */
+		/** Blocks field namespace. */
 		const FIELD_NAMESPACE = 'booster-wcj';
 
-		/**
-		 * Total number of checkout custom fields configured.
-		 *
-		 * @var int
-		 */
+		/** Store API extension namespace. */
+		const STORE_API_NAMESPACE = 'booster-wcj';
+
+		/** Minimum WooCommerce version with conditional additional fields. */
+		const CONDITIONAL_FIELDS_MIN_VERSION = '9.9.0';
+
+		/** @var int Total configured fields for the current tier. */
 		private $total_fields;
 
-		/**
-		 * Field types supported on WooCommerce Blocks checkout.
-		 * Radio is included and converted to select during registration.
-		 *
-		 * @var array
-		 */
+		/** @var array Types supported by the Additional Checkout Fields API. */
 		private $supported_types = array( 'text', 'select', 'checkbox', 'radio' );
 
-		/**
-		 * Cached field configuration loaded once during registration.
-		 *
-		 * @var array|null
-		 */
+		/** @var array|null Request-scoped field configuration. */
 		private $field_config_cache = null;
+
+		/** @var array|null Request-scoped cart product IDs. */
+		private $cart_product_ids_cache = null;
+
+		/** @var array|null Request-scoped cart category IDs. */
+		private $cart_category_ids_cache = null;
 
 		/**
 		 * Constructor.
 		 *
-		 * @version 8.0.0
+		 * @version 8.1.0
 		 * @since   7.12.0
-		 * @param int $total_fields Total number of configured checkout custom fields.
+		 * @param int $total_fields Total configured fields for the current tier.
 		 */
 		public function __construct( $total_fields ) {
-			$this->total_fields = $total_fields;
+			$this->total_fields = max( 0, (int) $total_fields );
 
 			add_action( 'woocommerce_init', array( $this, 'register_blocks_checkout_fields' ) );
-			add_action( 'woocommerce_store_api_checkout_order_processed', array( $this, 'bridge_blocks_meta_to_booster_format' ) );
+			add_action( 'woocommerce_set_additional_field_value', array( $this, 'bridge_additional_field_value' ), 10, 4 );
+
+			if ( did_action( 'woocommerce_blocks_loaded' ) ) {
+				$this->register_store_api_data();
+			} else {
+				add_action( 'woocommerce_blocks_loaded', array( $this, 'register_store_api_data' ) );
+			}
 		}
 
 		/**
-		 * Check if the WC Blocks additional checkout fields API is available.
+		 * Whether the Additional Checkout Fields API is available.
 		 *
-		 * @version 7.12.0
-		 * @since   7.12.0
 		 * @return bool
 		 */
 		private function is_blocks_api_available() {
@@ -97,25 +80,41 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 		}
 
 		/**
-		 * Get the WC Blocks field ID for a given Booster field index.
+		 * Whether conditional additional fields are supported.
 		 *
-		 * @version 7.12.0
-		 * @since   7.12.0
+		 * @return bool
+		 */
+		private function supports_conditional_fields() {
+			return defined( 'WC_VERSION' ) && version_compare( WC_VERSION, self::CONDITIONAL_FIELDS_MIN_VERSION, '>=' );
+		}
+
+		/**
+		 * Get a Blocks field ID.
+		 *
 		 * @param int $field_index Booster field index.
 		 * @return string
 		 */
 		private function get_blocks_field_id( $field_index ) {
-			return self::FIELD_NAMESPACE . '/checkout-field-' . $field_index;
+			return self::FIELD_NAMESPACE . '/checkout-field-' . absint( $field_index );
 		}
 
 		/**
-		 * Load and cache all field configuration in a single pass.
+		 * Normalize an option containing IDs.
 		 *
-		 * Avoids N+1 option queries by loading all enabled field configs at once.
+		 * @param mixed $value Option value.
+		 * @return array
+		 */
+		private function normalize_id_list( $value ) {
+			if ( ! is_array( $value ) ) {
+				$value = '' === $value || null === $value ? array() : array( $value );
+			}
+			return array_values( array_unique( array_filter( array_map( 'strval', $value ), 'strlen' ) ) );
+		}
+
+		/**
+		 * Load all supported field configuration once per request.
 		 *
-		 * @version 8.0.0
-		 * @since   8.0.0
-		 * @return array Associative array keyed by field index.
+		 * @return array
 		 */
 		private function get_all_field_configs() {
 			if ( null !== $this->field_config_cache ) {
@@ -123,78 +122,244 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 			}
 
 			$this->field_config_cache = array();
-
 			for ( $i = 1; $i <= $this->total_fields; $i++ ) {
-				$enabled = wcj_get_option( 'wcj_checkout_custom_field_enabled_' . $i );
-				if ( 'yes' !== $enabled ) {
+				if ( 'yes' !== wcj_get_option( 'wcj_checkout_custom_field_enabled_' . $i ) ) {
 					continue;
 				}
 
-				$booster_type = wcj_get_option( 'wcj_checkout_custom_field_type_' . $i, 'text' );
-				if ( ! in_array( $booster_type, $this->supported_types, true ) ) {
+				$type = wcj_get_option( 'wcj_checkout_custom_field_type_' . $i, 'text' );
+				if ( ! in_array( $type, $this->supported_types, true ) ) {
 					continue;
 				}
 
-				$this->field_config_cache[ $i ] = array(
-					'type'           => $booster_type,
+				$config = array(
+					'type'           => $type,
 					'label'          => wcj_get_option( 'wcj_checkout_custom_field_label_' . $i, '' ),
-					'required'       => ( 'yes' === wcj_get_option( 'wcj_checkout_custom_field_required_' . $i, 'no' ) ),
+					'required'       => 'yes' === wcj_get_option( 'wcj_checkout_custom_field_required_' . $i, 'no' ),
 					'section'        => wcj_get_option( 'wcj_checkout_custom_field_section_' . $i, 'billing' ),
 					'select_options' => wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $i, '' ),
+					'categories_ex'  => $this->normalize_id_list( wcj_get_option( 'wcj_checkout_custom_field_categories_ex_' . $i, array() ) ),
+					'categories_in'  => $this->normalize_id_list( wcj_get_option( 'wcj_checkout_custom_field_categories_in_' . $i, array() ) ),
+					'products_ex'    => $this->normalize_id_list( wcj_get_option( 'wcj_checkout_custom_field_products_ex_' . $i, array() ) ),
+					'products_in'    => $this->normalize_id_list( wcj_get_option( 'wcj_checkout_custom_field_products_in_' . $i, array() ) ),
+					'min_cart'       => (float) wcj_get_option( 'wcj_checkout_custom_field_min_cart_amount_' . $i, 0 ),
+					'max_cart'       => (float) wcj_get_option( 'wcj_checkout_custom_field_max_cart_amount_' . $i, 0 ),
 				);
+				$config['conditioned'] = ! empty( $config['categories_ex'] ) || ! empty( $config['categories_in'] ) || ! empty( $config['products_ex'] ) || ! empty( $config['products_in'] ) || $config['min_cart'] > 0 || $config['max_cart'] > 0;
+
+				$this->field_config_cache[ $i ] = $config;
 			}
 
 			return $this->field_config_cache;
 		}
 
 		/**
-		 * Register Booster checkout custom fields with the WC Blocks API.
+		 * Register contextual field visibility on the Cart Store API schema.
+		 */
+		public function register_store_api_data() {
+			if ( ! function_exists( 'woocommerce_store_api_register_endpoint_data' ) || ! class_exists( '\\Automattic\\WooCommerce\\StoreApi\\Schemas\\V1\\CartSchema' ) ) {
+				return;
+			}
+
+			woocommerce_store_api_register_endpoint_data(
+				array(
+					'endpoint'        => \Automattic\WooCommerce\StoreApi\Schemas\V1\CartSchema::IDENTIFIER,
+					'namespace'       => self::STORE_API_NAMESPACE,
+					'data_callback'   => array( $this, 'get_store_api_data' ),
+					'schema_callback' => array( $this, 'get_store_api_schema' ),
+					'schema_type'     => ARRAY_A,
+				)
+			);
+		}
+
+		/**
+		 * Store API data used by Checkout block JSON Schema conditions.
 		 *
-		 * Only registers fields with supported types (text, select, checkbox, radio).
-		 * Radio fields are converted to select dropdowns since the Blocks API does
-		 * not support native radio inputs.
+		 * @return array
+		 */
+		public function get_store_api_data() {
+			$visibility = array();
+			foreach ( $this->get_all_field_configs() as $i => $config ) {
+				$visibility[ 'field_' . $i ] = $this->is_field_visible( $i, $config );
+			}
+			return array( 'checkout_field_visibility' => $visibility );
+		}
+
+		/**
+		 * Schema for contextual Checkout field visibility.
 		 *
-		 * All fields use the 'order' location so they appear in the
-		 * order/additional-information area of the Checkout block.
+		 * @return array
+		 */
+		public function get_store_api_schema() {
+			$properties = array();
+			foreach ( $this->get_all_field_configs() as $i => $config ) {
+				$properties[ 'field_' . $i ] = array(
+					'description' => __( 'Whether this Booster checkout field is visible for the current cart.', 'woocommerce-jetpack' ),
+					'type'        => 'boolean',
+					'readonly'    => true,
+				);
+			}
+			return array(
+				'checkout_field_visibility' => array(
+					'description' => __( 'Booster checkout field visibility for the current cart.', 'woocommerce-jetpack' ),
+					'type'        => 'object',
+					'properties'  => $properties,
+					'readonly'    => true,
+				),
+			);
+		}
+
+		/**
+		 * Get current cart product IDs once per request.
 		 *
-		 * Visibility conditions (product/category/cart-amount) are NOT evaluated
-		 * here because the WC Blocks API registers fields at plugin init, before
-		 * cart context is available. Visibility remains classic-checkout-only.
+		 * @return array
+		 */
+		private function get_cart_product_ids() {
+			if ( null !== $this->cart_product_ids_cache ) {
+				return $this->cart_product_ids_cache;
+			}
+			$this->cart_product_ids_cache = array();
+			if ( function_exists( 'WC' ) && WC()->cart ) {
+				foreach ( WC()->cart->get_cart() as $cart_item ) {
+					if ( isset( $cart_item['product_id'] ) ) {
+						$this->cart_product_ids_cache[] = (string) $cart_item['product_id'];
+					}
+				}
+			}
+			return array_values( array_unique( $this->cart_product_ids_cache ) );
+		}
+
+		/**
+		 * Get current cart category IDs once per request.
 		 *
-		 * @version 8.0.0
-		 * @since   7.12.0
+		 * @return array
+		 */
+		private function get_cart_category_ids() {
+			if ( null !== $this->cart_category_ids_cache ) {
+				return $this->cart_category_ids_cache;
+			}
+			$this->cart_category_ids_cache = array();
+			foreach ( $this->get_cart_product_ids() as $product_id ) {
+				$category_ids = wp_get_post_terms( (int) $product_id, 'product_cat', array( 'fields' => 'ids' ) );
+				if ( ! is_wp_error( $category_ids ) ) {
+					$this->cart_category_ids_cache = array_merge( $this->cart_category_ids_cache, array_map( 'strval', $category_ids ) );
+				}
+			}
+			$this->cart_category_ids_cache = array_values( array_unique( $this->cart_category_ids_cache ) );
+			return $this->cart_category_ids_cache;
+		}
+
+		/**
+		 * Evaluate the existing Booster visibility rules without recalculating cart totals.
+		 *
+		 * The products-in early return intentionally preserves the Classic Checkout
+		 * rule precedence used by existing stores.
+		 *
+		 * @param int   $field_index Field index.
+		 * @param array $config      Normalized field config.
+		 * @return bool
+		 */
+		private function is_field_visible( $field_index, $config ) {
+			if ( ! function_exists( 'WC' ) || ! WC()->cart ) {
+				return ! $config['conditioned'];
+			}
+			if ( apply_filters( 'wcj_checkout_custom_field_always_visible_on_empty_cart', false ) && WC()->cart->is_empty() ) {
+				return true;
+			}
+
+			$product_ids  = $this->get_cart_product_ids();
+			$category_ids = $this->get_cart_category_ids();
+			if ( ! empty( array_intersect( $config['categories_ex'], $category_ids ) ) ) {
+				return false;
+			}
+			if ( ! empty( $config['categories_in'] ) && empty( array_intersect( $config['categories_in'], $category_ids ) ) ) {
+				return false;
+			}
+			if ( ! empty( array_intersect( $config['products_ex'], $product_ids ) ) ) {
+				return false;
+			}
+			if ( ! empty( $config['products_in'] ) ) {
+				return ! empty( array_intersect( $config['products_in'], $product_ids ) );
+			}
+
+			$cart_total = (float) WC()->cart->get_total( 'edit' );
+			if ( $config['min_cart'] > 0 && $cart_total < $config['min_cart'] ) {
+				return false;
+			}
+			if ( $config['max_cart'] > 0 && $cart_total > $config['max_cart'] ) {
+				return false;
+			}
+
+			return (bool) apply_filters( 'wcj_checkout_custom_field_visible', true, $field_index );
+		}
+
+		/**
+		 * Build a document-object condition for a field visibility value.
+		 *
+		 * @param int  $field_index Field index.
+		 * @param bool $visible     Required visibility state.
+		 * @return array
+		 */
+		private function get_visibility_condition( $field_index, $visible ) {
+			return array(
+				'cart' => array(
+					'properties' => array(
+						'extensions' => array(
+							'properties' => array(
+								self::STORE_API_NAMESPACE => array(
+									'properties' => array(
+										'checkout_field_visibility' => array(
+											'properties' => array(
+												'field_' . $field_index => array( 'const' => (bool) $visible ),
+											),
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			);
+		}
+
+		/**
+		 * Register supported fields with the Checkout block.
 		 */
 		public function register_blocks_checkout_fields() {
 			if ( ! $this->is_blocks_api_available() ) {
 				return;
 			}
 
-			$configs = $this->get_all_field_configs();
-
-			foreach ( $configs as $i => $config ) {
-				$blocks_type = $config['type'];
-
-				// Convert radio to select for Blocks (no native radio support).
-				if ( 'radio' === $blocks_type ) {
-					$blocks_type = 'select';
+			foreach ( $this->get_all_field_configs() as $i => $config ) {
+				if ( $config['conditioned'] && ! $this->supports_conditional_fields() ) {
+					continue;
 				}
 
-				$field_args = array(
-					'id'       => $this->get_blocks_field_id( $i ),
-					'label'    => $config['label'],
-					'location' => 'order',
-					'type'     => $blocks_type,
-					'required' => $config['required'],
+				$blocks_type = 'radio' === $config['type'] ? 'select' : $config['type'];
+				$field_args  = array(
+					'id'                => $this->get_blocks_field_id( $i ),
+					'label'             => $config['label'],
+					'location'          => 'order',
+					'type'              => $blocks_type,
+					'required'          => $config['required'],
+					'sanitize_callback' => array( $this, 'sanitize_field_value' ),
 				);
 
-				// Select and radio-as-select both need options.
-				if ( 'select' === $blocks_type ) {
-					$options_raw = $config['select_options'];
-					// For radio fields, options are stored in the same format.
-					if ( 'radio' === $config['type'] ) {
-						$options_raw = wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $i, '' );
+				if ( $config['conditioned'] ) {
+					$field_args['hidden'] = $this->get_visibility_condition( $i, false );
+					if ( $config['required'] ) {
+						$field_args['required'] = $this->get_visibility_condition( $i, true );
 					}
-					$field_args['options'] = $this->format_select_options_for_blocks( $options_raw );
+				}
+
+				if ( 'select' === $blocks_type ) {
+					$field_args['options']           = $this->format_select_options_for_blocks( $config['select_options'] );
+					$field_args['validate_callback'] = function ( $value ) use ( $config ) {
+						$allowed = wp_list_pluck( $this->format_select_options_for_blocks( $config['select_options'] ), 'value' );
+						if ( '' !== $value && ! in_array( $value, $allowed, true ) ) {
+							return new \WP_Error( 'wcj_invalid_checkout_field', __( 'Please select a valid checkout field option.', 'woocommerce-jetpack' ) );
+						}
+					};
 				}
 
 				woocommerce_register_additional_checkout_field( $field_args );
@@ -202,190 +367,93 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields_Blocks' ) ) :
 		}
 
 		/**
-		 * Convert Booster's newline-separated select options to the WC Blocks format.
+		 * Sanitize a Blocks field value.
 		 *
-		 * Booster stores select options as a newline-separated string.
-		 * WC Blocks expects an array of { label, value } arrays.
-		 *
-		 * @version 7.12.0
-		 * @since   7.12.0
-		 * @param string $options_raw Newline-separated options from Booster settings.
-		 * @return array
+		 * @param mixed $value Submitted value.
+		 * @return mixed
 		 */
-		private function format_select_options_for_blocks( $options_raw ) {
-			$blocks_options = array();
-			if ( '' === $options_raw ) {
-				return $blocks_options;
-			}
-
-			$lines = array_map( 'trim', explode( PHP_EOL, $options_raw ) );
-			foreach ( $lines as $line ) {
-				if ( '' === $line ) {
-					continue;
-				}
-				$blocks_options[] = array(
-					'label' => $line,
-					'value' => urldecode( sanitize_title( $line ) ),
-				);
-			}
-
-			return $blocks_options;
+		public function sanitize_field_value( $value ) {
+			return is_bool( $value ) ? $value : wc_clean( wp_unslash( $value ) );
 		}
 
 		/**
-		 * Reverse-map a Blocks select slug back to the raw Booster option label.
+		 * Convert Booster newline-separated options to Blocks options.
 		 *
-		 * During registration, raw Booster option labels are converted to slugs
-		 * via sanitize_title(). This reverses that mapping so the bridged meta
-		 * stores the same raw label that the classic checkout path would store.
-		 *
-		 * Works for both select and radio-as-select fields.
-		 *
-		 * @version 8.0.0
-		 * @since   7.12.0
-		 * @param int    $field_index Booster field index.
-		 * @param string $slug        The sanitized slug submitted by Blocks checkout.
-		 * @return string The raw Booster option label, or the slug if no match found.
+		 * @param string $options_raw Stored options.
+		 * @return array
 		 */
-		private function reverse_map_select_value( $field_index, $slug ) {
-			$configs     = $this->get_all_field_configs();
-			$options_raw = '';
-
-			if ( isset( $configs[ $field_index ] ) ) {
-				$options_raw = $configs[ $field_index ]['select_options'];
-				if ( 'radio' === $configs[ $field_index ]['type'] && '' === $options_raw ) {
-					$options_raw = wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $field_index, '' );
+		private function format_select_options_for_blocks( $options_raw ) {
+			$options = array();
+			foreach ( preg_split( '/\\r\\n|\\r|\\n/', (string) $options_raw ) as $line ) {
+				$line = trim( $line );
+				if ( '' !== $line ) {
+					$options[] = array(
+						'label' => $line,
+						'value' => urldecode( sanitize_title( $line ) ),
+					);
 				}
 			}
+			return $options;
+		}
 
-			if ( '' === $options_raw ) {
-				$options_raw = wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $field_index, '' );
-			}
-
-			if ( '' === $options_raw ) {
-				return $slug;
-			}
-
-			$lines = array_map( 'trim', explode( PHP_EOL, $options_raw ) );
-			foreach ( $lines as $line ) {
-				if ( '' === $line ) {
-					continue;
-				}
-				if ( urldecode( sanitize_title( $line ) ) === $slug ) {
-					return $line;
+		/**
+		 * Map a Blocks option slug to the stored Booster label.
+		 *
+		 * @param array  $config Field config.
+		 * @param string $slug   Blocks value.
+		 * @return string
+		 */
+		private function reverse_map_select_value( $config, $slug ) {
+			foreach ( $this->format_select_options_for_blocks( $config['select_options'] ) as $option ) {
+				if ( $option['value'] === $slug ) {
+					return $option['label'];
 				}
 			}
-
 			return $slug;
 		}
 
 		/**
-		 * Get the WC Blocks CheckoutFields service instance.
+		 * Bridge a Blocks field into the legacy Booster order-meta shape.
 		 *
-		 * @version 7.12.0
-		 * @since   7.12.0
-		 * @return object|false The CheckoutFields service or false if unavailable.
+		 * WooCommerce saves the order object after this hook, so this method only
+		 * mutates the object and deliberately does not trigger an extra save.
+		 *
+		 * @param string    $key       Additional field key.
+		 * @param mixed     $value     Saved value.
+		 * @param string    $group     Field group.
+		 * @param WC_Data   $wc_object WooCommerce data object.
 		 */
-		private function get_checkout_fields_service() {
-			if ( ! class_exists( 'Automattic\WooCommerce\Blocks\Package' ) ) {
-				return false;
-			}
-			try {
-				$container = \Automattic\WooCommerce\Blocks\Package::container();
-				return $container->get( \Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields::class );
-			} catch ( \Exception $e ) {
-				return false;
-			}
-		}
-
-		/**
-		 * Bridge WC Blocks meta to Booster meta format after a Blocks checkout.
-		 *
-		 * When a customer checks out via WooCommerce Blocks, field data is saved
-		 * by the Store API using the Blocks meta key format. This method reads
-		 * that data using the WC CheckoutFields service (the recommended access
-		 * path) and copies it into Booster's expected meta key format
-		 * (_SECTION_wcj_checkout_field_N) so that existing admin order display,
-		 * emails, shortcodes, and store exporters continue to work.
-		 *
-		 * @version 8.0.0
-		 * @since   7.12.0
-		 * @param \WC_Order $order The order object.
-		 */
-		public function bridge_blocks_meta_to_booster_format( $order ) {
-			$checkout_fields_service = $this->get_checkout_fields_service();
-			$configs                 = $this->get_all_field_configs();
-			$bridged_any             = false;
-
-			foreach ( $configs as $i => $config ) {
-				$booster_type = $config['type'];
-
-				$field_id     = $this->get_blocks_field_id( $i );
-				$blocks_value = '';
-
-				// All fields use 'order' location → 'other' service group.
-				if ( $checkout_fields_service && method_exists( $checkout_fields_service, 'get_field_from_object' ) ) {
-					$blocks_value = $checkout_fields_service->get_field_from_object( $field_id, $order, 'other' );
-				}
-
-				// Fallback: try direct meta read if the service returned empty.
-				if ( '' === $blocks_value || false === $blocks_value || null === $blocks_value ) {
-					$blocks_value = $order->get_meta( '_wc_other/' . $field_id );
-				}
-
-				// Skip fields with no value (except checkboxes which can be unchecked).
-				if ( '' === $blocks_value || false === $blocks_value || null === $blocks_value ) {
-					if ( 'checkbox' !== $booster_type ) {
-						continue;
-					}
-					$blocks_value = '';
-				}
-
-				$section = $config['section'];
-				$label   = $config['label'];
-
-				$booster_key       = '_' . $section . '_wcj_checkout_field_' . $i;
-				$booster_key_label = '_' . $section . '_wcj_checkout_field_label_' . $i;
-				$booster_key_type  = '_' . $section . '_wcj_checkout_field_type_' . $i;
-
-				// Normalize checkbox values.
-				if ( 'checkbox' === $booster_type ) {
-					$blocks_value = ( ! empty( $blocks_value ) && 'false' !== $blocks_value && '0' !== $blocks_value ) ? 1 : 0;
-				}
-
-				// Reverse-map select/radio slug back to the raw Booster option label.
-				if ( in_array( $booster_type, array( 'select', 'radio' ), true ) ) {
-					$blocks_value = $this->reverse_map_select_value( $i, $blocks_value );
-				}
-
-				$order->update_meta_data( $booster_key, $blocks_value );
-				$order->update_meta_data( $booster_key_label, $label );
-				$order->update_meta_data( $booster_key_type, $booster_type );
-
-				// Store checkbox display text.
-				if ( 'checkbox' === $booster_type ) {
-					$checkbox_key   = '_' . $section . '_wcj_checkout_field_checkbox_value_' . $i;
-					$checkbox_value = ( 1 === (int) $blocks_value )
-						? get_option( 'wcj_checkout_custom_field_checkbox_yes_' . $i, '' )
-						: get_option( 'wcj_checkout_custom_field_checkbox_no_' . $i, '' );
-					$order->update_meta_data( $checkbox_key, $checkbox_value );
-				}
-
-				// Store select/radio options string for display resolution.
-				if ( in_array( $booster_type, array( 'select', 'radio' ), true ) ) {
-					$select_key = '_' . $section . '_wcj_checkout_field_select_options_' . $i;
-					$the_values = $config['select_options'];
-					if ( '' === $the_values ) {
-						$the_values = wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $i, '' );
-					}
-					$order->update_meta_data( $select_key, $the_values );
-				}
-
-				$bridged_any = true;
+		public function bridge_additional_field_value( $key, $value, $group, $wc_object ) {
+			if ( 'other' !== $group || ! is_a( $wc_object, 'WC_Order' ) ) {
+				return;
 			}
 
-			if ( $bridged_any ) {
-				$order->save();
+			foreach ( $this->get_all_field_configs() as $i => $config ) {
+				if ( $this->get_blocks_field_id( $i ) !== $key ) {
+					continue;
+				}
+
+				if ( 'checkbox' === $config['type'] ) {
+					$value = ! empty( $value ) && 'false' !== $value && '0' !== $value ? 1 : 0;
+				} elseif ( in_array( $config['type'], array( 'select', 'radio' ), true ) ) {
+					$value = $this->reverse_map_select_value( $config, (string) $value );
+				}
+
+				$prefix = '_' . $config['section'] . '_wcj_checkout_field_';
+				$wc_object->update_meta_data( $prefix . $i, $value );
+				$wc_object->update_meta_data( $prefix . 'label_' . $i, $config['label'] );
+				$wc_object->update_meta_data( $prefix . 'type_' . $i, $config['type'] );
+
+				if ( 'checkbox' === $config['type'] ) {
+					$display = $value
+						? wcj_get_option( 'wcj_checkout_custom_field_checkbox_yes_' . $i, '' )
+						: wcj_get_option( 'wcj_checkout_custom_field_checkbox_no_' . $i, '' );
+					$wc_object->update_meta_data( $prefix . 'checkbox_value_' . $i, $display );
+				}
+				if ( in_array( $config['type'], array( 'select', 'radio' ), true ) ) {
+					$wc_object->update_meta_data( $prefix . 'select_options_' . $i, $config['select_options'] );
+				}
+				break;
 			}
 		}
 	}

--- a/includes/class-wcj-checkout-custom-fields.php
+++ b/includes/class-wcj-checkout-custom-fields.php
@@ -50,7 +50,7 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields' ) ) :
 		/**
 		 * Constructor.
 		 *
-		 * @version 7.1.4
+		 * @version 8.1.0
 		 * @todo    (maybe) check if `'wcj_checkout_custom_field_customer_meta_fields_' . $i` option should affect `add_default_checkout_custom_fields`
 		 */
 		public function __construct() {
@@ -295,73 +295,69 @@ if ( ! class_exists( 'WCJ_Checkout_Custom_Fields' ) ) :
 		 * @param string $order_id defines the order_id.
 		 */
 		public function update_custom_checkout_fields_order_meta( $order_id ) {
-			for ( $i = 1; $i <= $this->wcj_checkout_custom_fields_total_number; $i++ ) {
-				if ( 'yes' === wcj_get_option( 'wcj_checkout_custom_field_enabled_' . $i ) ) {
-					if ( 'woocommerce_checkout_update_order_meta' === current_filter() && ! $this->is_visible( $i ) ) {
-						continue;
-					}
-					$the_section       = wcj_get_option( 'wcj_checkout_custom_field_section_' . $i );
-					$the_type          = wcj_get_option( 'wcj_checkout_custom_field_type_' . $i );
-					$option_name       = $the_section . '_wcj_checkout_field_' . $i;
-					$option_name_label = $the_section . '_wcj_checkout_field_label_' . $i;
-					$option_name_type  = $the_section . '_wcj_checkout_field_type_' . $i;
+			$current_hook = current_filter();
+			$is_checkout  = 'woocommerce_checkout_update_order_meta' === $current_hook;
 
-					if ( true === wcj_is_hpos_enabled() ) {
-
-						$order = wcj_get_order( $order_id );
-						if ( $order && false !== $order ) {
-							$post_value = isset( $_POST[ $option_name ] ) ? ( sanitize_text_field( wp_unslash( $_POST[ $option_name ] ) ) ) : ( isset( $_POST[ '_' . $option_name ] ) ? ( sanitize_text_field( wp_unslash( $_POST[ '_' . $option_name ] ) ) ) : $order->get_meta( '_' . $option_name ) ); // phpcs:ignore WordPress.Security.NonceVerification
-							if ( ! empty( $post_value ) || 'checkbox' === $the_type ) {
-								$order->update_meta_data( '_' . $option_name_type, $the_type );
-								$order->update_meta_data( '_' . $option_name_label, wcj_get_option( 'wcj_checkout_custom_field_label_' . $i ) );
-								if ( 'checkbox' === $the_type ) {
-									$the_value = ! empty( $post_value ) ? 1 : 0;
-									$order->update_meta_data( '_' . $option_name, $the_value );
-									$option_name_checkbox_value = $the_section . '_wcj_checkout_field_checkbox_value_' . $i;
-									$checkbox_value             = ( 1 === $the_value ) ?
-									get_option( 'wcj_checkout_custom_field_checkbox_yes_' . $i ) :
-									get_option( 'wcj_checkout_custom_field_checkbox_no_' . $i );
-									$order->update_meta_data( '_' . $option_name_checkbox_value, $checkbox_value );
-								} elseif ( 'radio' === $the_type || 'select' === $the_type ) {
-									$order->update_meta_data( '_' . $option_name, wc_clean( urldecode( $post_value ) ) );
-									$option_name_values = $the_section . '_wcj_checkout_field_select_options_' . $i;
-									$the_values         = wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $i );
-									$order->update_meta_data( '_' . $option_name_values, $the_values );
-								} elseif ( 'textarea' === $the_type && 'no' === wcj_get_option( 'wcj_checkout_custom_fields_textarea_clean', 'yes' ) ) {
-									$order->update_meta_data( '_' . $option_name, urldecode( $post_value ) );
-								} else {
-									$order->update_meta_data( '_' . $option_name, wc_clean( urldecode( $post_value ) ) );
-								}
-								$order->save();
-							}
-						}
-					} else {
-
-						$post_value = isset( $_POST[ $option_name ] ) ? ( sanitize_text_field( wp_unslash( $_POST[ $option_name ] ) ) ) : ( isset( $_POST[ '_' . $option_name ] ) ? ( sanitize_text_field( wp_unslash( $_POST[ '_' . $option_name ] ) ) ) : get_post_meta( $order_id, '_' . $option_name, true ) ); // phpcs:ignore WordPress.Security.NonceVerification
-						if ( ! empty( $post_value ) || 'checkbox' === $the_type ) {
-							update_post_meta( $order_id, '_' . $option_name_type, $the_type );
-							update_post_meta( $order_id, '_' . $option_name_label, wcj_get_option( 'wcj_checkout_custom_field_label_' . $i ) );
-							if ( 'checkbox' === $the_type ) {
-								$the_value = ! empty( $post_value ) ? 1 : 0;
-								update_post_meta( $order_id, '_' . $option_name, $the_value );
-								$option_name_checkbox_value = $the_section . '_wcj_checkout_field_checkbox_value_' . $i;
-								$checkbox_value             = ( 1 === $the_value ) ?
-								get_option( 'wcj_checkout_custom_field_checkbox_yes_' . $i ) :
-								get_option( 'wcj_checkout_custom_field_checkbox_no_' . $i );
-								update_post_meta( $order_id, '_' . $option_name_checkbox_value, $checkbox_value );
-							} elseif ( 'radio' === $the_type || 'select' === $the_type ) {
-								update_post_meta( $order_id, '_' . $option_name, wc_clean( urldecode( $post_value ) ) );
-								$option_name_values = $the_section . '_wcj_checkout_field_select_options_' . $i;
-								$the_values         = wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $i );
-								update_post_meta( $order_id, '_' . $option_name_values, $the_values );
-							} elseif ( 'textarea' === $the_type && 'no' === wcj_get_option( 'wcj_checkout_custom_fields_textarea_clean', 'yes' ) ) {
-								update_post_meta( $order_id, '_' . $option_name, urldecode( $post_value ) );
-							} else {
-								update_post_meta( $order_id, '_' . $option_name, wc_clean( urldecode( $post_value ) ) );
-							}
-						}
-					}
+			// WooCommerce verifies checkout requests before firing the checkout hook.
+			// Admin saves need an explicit capability and WooCommerce meta-box nonce.
+			if ( ! $is_checkout ) {
+				$nonce = isset( $_POST['woocommerce_meta_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['woocommerce_meta_nonce'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+				if ( ! current_user_can( 'edit_shop_order', $order_id ) || ! wp_verify_nonce( $nonce, 'woocommerce_save_data' ) ) {
+					return;
 				}
+			}
+
+			$order = wc_get_order( $order_id );
+			if ( ! $order ) {
+				return;
+			}
+
+			$changed = false;
+			for ( $i = 1; $i <= $this->wcj_checkout_custom_fields_total_number; $i++ ) {
+				if ( 'yes' !== wcj_get_option( 'wcj_checkout_custom_field_enabled_' . $i ) ) {
+					continue;
+				}
+				if ( $is_checkout && ! $this->is_visible( $i ) ) {
+					continue;
+				}
+
+				$section     = wcj_get_option( 'wcj_checkout_custom_field_section_' . $i );
+				$type        = wcj_get_option( 'wcj_checkout_custom_field_type_' . $i );
+				$option_name = $section . '_wcj_checkout_field_' . $i;
+				if ( isset( $_POST[ $option_name ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+					$post_value = sanitize_text_field( wp_unslash( $_POST[ $option_name ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+				} elseif ( isset( $_POST[ '_' . $option_name ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+					$post_value = sanitize_text_field( wp_unslash( $_POST[ '_' . $option_name ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+				} else {
+					$post_value = $order->get_meta( '_' . $option_name );
+				}
+
+				if ( empty( $post_value ) && 'checkbox' !== $type ) {
+					continue;
+				}
+
+				$order->update_meta_data( '_' . $section . '_wcj_checkout_field_type_' . $i, $type );
+				$order->update_meta_data( '_' . $section . '_wcj_checkout_field_label_' . $i, wcj_get_option( 'wcj_checkout_custom_field_label_' . $i ) );
+				if ( 'checkbox' === $type ) {
+					$value = ! empty( $post_value ) ? 1 : 0;
+					$order->update_meta_data( '_' . $option_name, $value );
+					$order->update_meta_data(
+						'_' . $section . '_wcj_checkout_field_checkbox_value_' . $i,
+						$value ? wcj_get_option( 'wcj_checkout_custom_field_checkbox_yes_' . $i ) : wcj_get_option( 'wcj_checkout_custom_field_checkbox_no_' . $i )
+					);
+				} elseif ( in_array( $type, array( 'radio', 'select' ), true ) ) {
+					$order->update_meta_data( '_' . $option_name, wc_clean( urldecode( $post_value ) ) );
+					$order->update_meta_data( '_' . $section . '_wcj_checkout_field_select_options_' . $i, wcj_get_option( 'wcj_checkout_custom_field_select_options_' . $i ) );
+				} elseif ( 'textarea' === $type && 'no' === wcj_get_option( 'wcj_checkout_custom_fields_textarea_clean', 'yes' ) ) {
+					$order->update_meta_data( '_' . $option_name, urldecode( $post_value ) );
+				} else {
+					$order->update_meta_data( '_' . $option_name, wc_clean( urldecode( $post_value ) ) );
+				}
+				$changed = true;
+			}
+
+			if ( $changed ) {
+				$order->save();
 			}
 		}
 

--- a/includes/class-wcj-checkout-fees.php
+++ b/includes/class-wcj-checkout-fees.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Checkout Fees
  *
- * @version 8.0.0
+ * @version 8.1.0
  * @since   3.7.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -46,7 +46,7 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 		/**
 		 * Constructor.
 		 *
-		 * @version 8.0.0
+		 * @version 8.1.0
 		 * @since   3.7.0
 		 */
 		public function __construct() {
@@ -81,6 +81,15 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 		private function is_store_api_request() {
 			if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
 				return false;
+			}
+			$route = '';
+			if ( isset( $GLOBALS['wp']->query_vars['rest_route'] ) ) {
+				$route = sanitize_text_field( wp_unslash( $GLOBALS['wp']->query_vars['rest_route'] ) );
+			} elseif ( isset( $_GET['rest_route'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$route = sanitize_text_field( wp_unslash( $_GET['rest_route'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			}
+			if ( 0 === strpos( ltrim( $route, '/' ), 'wc/store/' ) ) {
+				return true;
 			}
 			$uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 			return false !== strpos( $uri, '/wc/store/' );
@@ -153,16 +162,22 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 					// Checkout-field-conditional fees are not supported on Blocks checkout.
 					return false;
 				}
-				if ( isset( $post_data ) || isset( $_REQUEST['post_data'] ) ) {
-					if ( ! isset( $post_data ) ) {
-						$post_data = array();
-						parse_str( sanitize_text_field( wp_unslash( $_REQUEST['post_data'] ) ), $post_data );
-						$wpnonce = isset( $post_data['wcj-process-checkout-nonce'] ) ? wp_verify_nonce( sanitize_key( $post_data['wcj-process-checkout-nonce'] ), 'wcj-process_checkout' ) : false;
-					}
-					if ( ! $wpnonce || empty( $post_data[ $this->checkout_fields[ $fee_id ] ] ) ) {
-						return false;
-					}
-				} elseif ( empty( $_REQUEST[ $this->checkout_fields[ $fee_id ] ] ) ) {
+				$post_data = array();
+				if ( isset( $_REQUEST['post_data'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+					parse_str( wp_unslash( $_REQUEST['post_data'] ), $post_data ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+				} else {
+					$post_data = wp_unslash( $_REQUEST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+				}
+				$nonce       = isset( $post_data['wcj-process-checkout-nonce'] ) ? sanitize_text_field( $post_data['wcj-process-checkout-nonce'] ) : '';
+				$nonce_valid = wp_verify_nonce( $nonce, 'wcj-process_checkout' );
+				if ( ! $nonce_valid && isset( $_REQUEST['wc-ajax'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+					$ajax_action = sanitize_key( wp_unslash( $_REQUEST['wc-ajax'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+					// WooCommerce verifies its checkout nonce before this action. A customer
+					// account created during checkout changes the user session and invalidates
+					// Booster's earlier guest nonce before the final cart recalculation.
+					$nonce_valid = ( 'checkout' === $ajax_action && did_action( 'woocommerce_checkout_process' ) );
+				}
+				if ( ! $nonce_valid || empty( $post_data[ $this->checkout_fields[ $fee_id ] ] ) ) {
 					return false;
 				}
 			}
@@ -240,7 +255,7 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 			$cart_max        = $this->get_fee_option( 'wcj_checkout_fees_cart_max_amount' );
 			$cart_max_total  = $this->get_fee_option( 'wcj_checkout_fees_cart_max_total_amount' );
 			$taxable         = $this->get_fee_option( 'wcj_checkout_fees_data_taxable' );
-			$checkout_fields = $this->get_fee_option( 'wcj_checkout_fees_data_values' );
+			$checkout_fields = $this->get_fee_option( 'wcj_checkout_fees_data_checkout_fields' );
 			$enabled         = $this->get_fee_option( 'wcj_checkout_fees_data_enabled' );
 			$overlap_opt     = $this->get_fee_option( 'wcj_checkout_fees_overlap' );
 			$priorities      = $this->get_fee_option( 'wcj_checkout_fees_priority' );
@@ -285,7 +300,7 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 		/**
 		 * Get valid fees.
 		 *
-		 * @version 8.0.0
+		 * @version 8.1.0
 		 * @since   4.5.0
 		 *
 		 * @param string | array $cart define cart details.
@@ -294,11 +309,6 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 		 * @return array
 		 */
 		public function get_valid_fees( $cart, $ignore_overlapped = true ) {
-			$titles  = $this->get_fee_option( 'wcj_checkout_fees_data_titles' );
-			$types   = $this->get_fee_option( 'wcj_checkout_fees_data_types' );
-			$values  = $this->get_fee_option( 'wcj_checkout_fees_data_values' );
-			$taxable = $this->get_fee_option( 'wcj_checkout_fees_data_taxable' );
-
 			$fees = $this->get_fees();
 
 			$fees_to_add = array();
@@ -319,16 +329,19 @@ if ( ! class_exists( 'WCJ_Checkout_Fees' ) ) :
 			}
 
 			foreach ( $valid_fees as $fee_id ) {
+				if ( ! isset( $fees[ $fee_id ] ) ) {
+					continue;
+				}
 				// Adding the fee.
-				$title = ( isset( $titles[ $fee_id ] ) ? $titles[ $fee_id ] : __( 'Fee', 'woocommerce-jetpack' ) . ' #' . $fee_id );
-				$value = isset( $values[ $fee_id ] ) ? $values[ $fee_id ] : 0;
-				if ( isset( $types[ $fee_id ] ) && 'percent' === $types[ $fee_id ] ) {
+				$title = '' !== $fees[ $fee_id ]['title'] ? $fees[ $fee_id ]['title'] : __( 'Fee', 'woocommerce-jetpack' ) . ' #' . $fee_id;
+				$value = $fees[ $fee_id ]['value'];
+				if ( 'percent' === $fees[ $fee_id ]['type'] ) {
 					$value = $cart->get_cart_contents_total() * $value / 100;
 				}
 				$fees_to_add[ $fee_id ] = array(
 					'name'      => $title,
 					'amount'    => $value,
-					'taxable'   => ( isset( $taxable[ $fee_id ] ) ? ( 'yes' === $taxable[ $fee_id ] ) : true ),
+					'taxable'   => 'yes' === $fees[ $fee_id ]['taxable'],
 					'tax_class' => 'standard',
 				);
 			}

--- a/includes/class-wcj-checkout-files-upload.php
+++ b/includes/class-wcj-checkout-files-upload.php
@@ -122,82 +122,79 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 		}
 
 		/**
-		 * Get order meta with HPOS compatibility.
+		 * Get checkout-file order meta through WooCommerce order CRUD.
 		 *
 		 * Consolidates the repeated if/else HPOS pattern into a single method.
 		 *
-		 * @version 8.0.0
+		 * @version 8.1.0
 		 * @since   8.0.0
 		 * @param int|WC_Order $order_or_id Order object or order ID.
 		 * @param string       $meta_key    Meta key to retrieve.
 		 * @return mixed
 		 */
 		private function get_order_file_meta( $order_or_id, $meta_key ) {
-			if ( true === wcj_is_hpos_enabled() ) {
-				$order = is_numeric( $order_or_id ) ? wcj_get_order( $order_or_id ) : $order_or_id;
-				if ( $order && false !== $order ) {
-					return $order->get_meta( $meta_key );
-				}
-				return '';
+			$order = is_numeric( $order_or_id ) ? wc_get_order( $order_or_id ) : $order_or_id;
+			if ( $order instanceof WC_Order ) {
+				return $order->get_meta( $meta_key );
 			}
+
+			// Compatibility fallback for legacy integrations passing a deleted order.
 			$order_id = is_numeric( $order_or_id ) ? $order_or_id : wcj_get_order_id( $order_or_id );
-			return get_post_meta( $order_id, $meta_key, true );
+			return $order_id ? get_post_meta( $order_id, $meta_key, true ) : '';
 		}
 
 		/**
-		 * Update order meta with HPOS compatibility.
+		 * Update checkout-file order meta through WooCommerce order CRUD.
 		 *
-		 * @version 8.0.0
+		 * @version 8.1.0
 		 * @since   8.0.0
 		 * @param int|WC_Order $order_or_id Order object or order ID.
 		 * @param string       $meta_key    Meta key to update.
 		 * @param mixed        $meta_value  Meta value.
 		 */
 		private function update_order_file_meta( $order_or_id, $meta_key, $meta_value ) {
-			if ( true === wcj_is_hpos_enabled() ) {
-				$order = is_numeric( $order_or_id ) ? wcj_get_order( $order_or_id ) : $order_or_id;
-				if ( $order && false !== $order ) {
-					$order->update_meta_data( $meta_key, $meta_value );
-				}
-			} else {
-				$order_id = is_numeric( $order_or_id ) ? $order_or_id : wcj_get_order_id( $order_or_id );
+			$order = is_numeric( $order_or_id ) ? wc_get_order( $order_or_id ) : $order_or_id;
+			if ( $order instanceof WC_Order ) {
+				$order->update_meta_data( $meta_key, $meta_value );
+				return;
+			}
+			$order_id = is_numeric( $order_or_id ) ? $order_or_id : wcj_get_order_id( $order_or_id );
+			if ( $order_id ) {
 				update_post_meta( $order_id, $meta_key, $meta_value );
 			}
 		}
 
 		/**
-		 * Delete order meta with HPOS compatibility.
+		 * Delete checkout-file order meta through WooCommerce order CRUD.
 		 *
-		 * @version 8.0.0
+		 * @version 8.1.0
 		 * @since   8.0.0
 		 * @param int|WC_Order $order_or_id Order object or order ID.
 		 * @param string       $meta_key    Meta key to delete.
 		 */
 		private function delete_order_file_meta( $order_or_id, $meta_key ) {
-			if ( true === wcj_is_hpos_enabled() ) {
-				$order = is_numeric( $order_or_id ) ? wcj_get_order( $order_or_id ) : $order_or_id;
-				if ( $order && false !== $order ) {
-					$order->delete_meta_data( $meta_key );
-				}
-			} else {
-				$order_id = is_numeric( $order_or_id ) ? $order_or_id : wcj_get_order_id( $order_or_id );
+			$order = is_numeric( $order_or_id ) ? wc_get_order( $order_or_id ) : $order_or_id;
+			if ( $order instanceof WC_Order ) {
+				$order->delete_meta_data( $meta_key );
+				return;
+			}
+			$order_id = is_numeric( $order_or_id ) ? $order_or_id : wcj_get_order_id( $order_or_id );
+			if ( $order_id ) {
 				delete_post_meta( $order_id, $meta_key );
 			}
 		}
 
 		/**
-		 * Save order after HPOS meta operations if needed.
+		 * Save an order once after batched checkout-file meta operations.
 		 *
-		 * @version 8.0.0
+		 * @version 8.1.0
 		 * @since   8.0.0
 		 * @param int|WC_Order $order_or_id Order object or order ID.
 		 */
 		private function save_order_if_hpos( $order_or_id ) {
-			if ( true === wcj_is_hpos_enabled() ) {
-				$order = is_numeric( $order_or_id ) ? wcj_get_order( $order_or_id ) : $order_or_id;
-				if ( $order && false !== $order ) {
-					$order->save();
-				}
+			$order = is_numeric( $order_or_id ) ? wc_get_order( $order_or_id ) : $order_or_id;
+			if ( $order instanceof WC_Order ) {
+				$order->save();
 			}
 		}
 
@@ -318,7 +315,7 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 		/**
 		 * Add_files_to_order_display.
 		 *
-		 * @version 7.1.4
+		 * @version 8.1.0
 		 * @since   2.4.7
 		 * @todo    (maybe) somehow add `%image%` to emails also
 		 * @param string | int $order defines the order.
@@ -346,8 +343,8 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 				if ( '' !== $real_file_name ) {
 					$img = '';
 					if ( $do_add_img ) {
-						$order_file_name = wcj_get_wcj_uploads_dir( 'checkout_files_upload' ) . '/' . $this->get_order_file_meta( $order, '_wcj_checkout_files_upload_' . $i );
-						if ( is_array( getimagesize( $order_file_name ) ) ) {
+						$order_file_name = $this->get_checkout_files_upload_real_path( $this->get_order_file_meta( $order, '_wcj_checkout_files_upload_' . $i ) );
+						if ( false !== $order_file_name && is_array( getimagesize( $order_file_name ) ) ) {
 							$link = esc_url(
 								add_query_arg(
 									array(
@@ -357,12 +354,12 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 									)
 								)
 							);
-							$img  = '<img style="' . $img_style . '" src="' . $link . '"> ';
+							$img  = '<img style="' . esc_attr( $img_style ) . '" src="' . $link . '"> ';
 						}
 					}
 					$html .= wcj_handle_replacements(
 						array(
-							'%file_name%' => $real_file_name,
+							'%file_name%' => esc_html( $real_file_name ),
 							'%image%'     => $img,
 						),
 						$template
@@ -393,7 +390,7 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 		/**
 		 * Validate_on_checkout.
 		 *
-		 * @version 7.2.5
+		 * @version 8.1.0
 		 * @since   2.4.5
 		 * @param string $posted defines the posted.
 		 */
@@ -496,29 +493,33 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 		public function create_file_admin_order_meta_box() {
 			$order_id     = get_the_ID();
 			$html         = '';
-			$total_files  = get_post_meta( $order_id, '_wcj_checkout_files_total_files', true );
+			$total_files  = absint( $this->get_order_file_meta( $order_id, '_wcj_checkout_files_total_files' ) );
 			$files_exists = false;
 			for ( $i = 1; $i <= $total_files; $i++ ) {
-				$order_file_name = get_post_meta( $order_id, '_wcj_checkout_files_upload_' . $i, true );
-				$real_file_name  = get_post_meta( $order_id, '_wcj_checkout_files_upload_real_name_' . $i, true );
+				$order_file_name = $this->get_order_file_meta( $order_id, '_wcj_checkout_files_upload_' . $i );
+				$real_file_name  = $this->get_order_file_meta( $order_id, '_wcj_checkout_files_upload_real_name_' . $i );
 				if ( '' !== $order_file_name && null !== $order_file_name ) {
 					$files_exists = true;
-					$html        .= '<p><a href="' . add_query_arg(
-						array(
-							'wcj_download_checkout_file_admin' => $order_file_name,
-							'wcj_checkout_file_number' => $i,
-							'wcj_download_checkout_file_admin_nonce' => wp_create_nonce( 'wcj_download_checkout_file_admin_nonce' ),
+					$html        .= '<p><a href="' . esc_url(
+						add_query_arg(
+							array(
+								'wcj_download_checkout_file_admin' => $order_file_name,
+								'wcj_checkout_file_number' => $i,
+								'wcj_download_checkout_file_admin_nonce' => wp_create_nonce( 'wcj_download_checkout_file_admin_nonce' ),
+							)
 						)
-					) . '">' . $real_file_name . '</a></p>';
+					) . '">' . esc_html( $real_file_name ) . '</a></p>';
 				}
 			}
 			if ( ! $files_exists ) {
 				$html .= '<p><em>' . __( 'No files uploaded.', 'woocommerce-jetpack' ) . '</em></p>';
 			} else {
-				$html .= '<p><a style="color:#a00;" href="' . add_query_arg(
-					array(
-						'wcj_download_checkout_file_admin_delete_all' => $order_id,
-						'wcj_download_checkout_file_admin_delete_all_nonce' => wp_create_nonce( 'wcj_download_checkout_file_admin_delete_all_nonce' ),
+				$html .= '<p><a style="color:#a00;" href="' . esc_url(
+					add_query_arg(
+						array(
+							'wcj_download_checkout_file_admin_delete_all' => $order_id,
+							'wcj_download_checkout_file_admin_delete_all_nonce' => wp_create_nonce( 'wcj_download_checkout_file_admin_delete_all_nonce' ),
+						)
 					)
 				) . '"' . wcj_get_js_confirmation() . '>' .
 					__( 'Delete all files', 'woocommerce-jetpack' ) . '</a></p>';
@@ -682,19 +683,14 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 		/**
 		 * Get_order_full_file_name.
 		 *
-		 * @version 7.1.4
+		 * @version 8.1.0
 		 * @since   3.8.0
 		 * @todo    use where needed
 		 * @param int          $order_id defines the order_id.
 		 * @param string | int $file_num defines the file_num.
 		 */
 		public function get_order_full_file_name( $order_id, $file_num ) {
-			$order = wcj_get_order( $order_id );
-			if ( true === wcj_is_hpos_enabled() && $order && false !== $order ) {
-				return wcj_get_wcj_uploads_dir( 'checkout_files_upload' ) . '/' . $order->get_meta( '_wcj_checkout_files_upload_' . $file_num );
-			} else {
-				return wcj_get_wcj_uploads_dir( 'checkout_files_upload' ) . '/' . get_post_meta( $order_id, '_wcj_checkout_files_upload_' . $file_num, true );
-			}
+			return $this->get_checkout_files_upload_real_path( $this->get_order_file_meta( $order_id, '_wcj_checkout_files_upload_' . absint( $file_num ) ) );
 		}
 
 		/**
@@ -734,21 +730,13 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 						continue;
 					}
 
-					if ( true === wcj_is_hpos_enabled() && $order && false !== $order ) {
-						$order_file_name = $order->get_meta( '_wcj_checkout_files_upload_' . $i );
-					} else {
-						$order_file_name = get_post_meta( $order_id, '_wcj_checkout_files_upload_' . $i, true );
-					}
+					$order_file_name = $this->get_order_file_meta( $order, '_wcj_checkout_files_upload_' . $i );
 					if ( '' !== $order_file_name && null !== $order_file_name ) {
 						$file_path = $this->get_checkout_files_upload_real_path( $order_file_name );
 						if ( false !== $file_path && file_exists( $file_path ) ) {
 							wp_delete_file( $file_path );
 						}
-						if ( true === wcj_is_hpos_enabled() && $order && false !== $order ) {
-							$file_name = $order->get_meta( '_wcj_checkout_files_upload_real_name_' . $i );
-						} else {
-							$file_name = get_post_meta( $order_id, '_wcj_checkout_files_upload_real_name_' . $i, true );
-						}
+						$file_name = $this->get_order_file_meta( $order, '_wcj_checkout_files_upload_real_name_' . $i );
 						$this->add_notice(
 							sprintf(
 								wcj_get_option(
@@ -759,14 +747,9 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 								$file_name
 							)
 						);
-						if ( true === wcj_is_hpos_enabled() && $order && false !== $order ) {
-							$order->delete_meta_data( '_wcj_checkout_files_upload_' . $i );
-							$order->delete_meta_data( '_wcj_checkout_files_upload_real_name_' . $i );
-							$order->save();
-						} else {
-							delete_post_meta( $order_id, '_wcj_checkout_files_upload_' . $i );
-							delete_post_meta( $order_id, '_wcj_checkout_files_upload_real_name_' . $i );
-						}
+						$this->delete_order_file_meta( $order, '_wcj_checkout_files_upload_' . $i );
+						$this->delete_order_file_meta( $order, '_wcj_checkout_files_upload_real_name_' . $i );
+						$this->save_order_if_hpos( $order );
 						if ( in_array( 'remove_file', $this->additional_admin_emails_settings['actions'], true ) ) {
 							wp_mail(
 								$admin_email,
@@ -890,8 +873,7 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 						// To session.
 						$tmp_dest_file = tempnam( wcj_get_wcj_uploads_dir( 'temp' ), 'wcj' );
 						if ( move_uploaded_file( $temp_file_name, $tmp_dest_file ) ) {
-							$session_data             = array_map( 'sanitize_text_field', wp_unslash( $_FILES[ $file_name ] ) );
-							$session_data['tmp_name'] = $tmp_dest_file;
+							$session_data = array_merge( array_map( 'sanitize_text_field', wp_unslash( $_FILES[ $file_name ] ) ), array( 'tmp_name' => $tmp_dest_file ) );
 							wcj_session_set( $file_name, $session_data );
 						}
 						$this->add_notice(
@@ -908,8 +890,9 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 						if ( 0 !== $order_id ) {
 							$this->add_files_to_order( $order_id, null );
 							if ( in_array( 'upload_file', $this->additional_admin_emails_settings['actions'], true ) ) {
-								$attachments = ( 'no' === $this->additional_admin_emails_settings['do_attach'] ?
-									array() : array( $this->get_order_full_file_name( $order_id, $i ) ) );
+								$attachment  = $this->get_order_full_file_name( $order_id, $i );
+								$attachments = ( 'no' === $this->additional_admin_emails_settings['do_attach'] || false === $attachment ?
+									array() : array( $attachment ) );
 								wp_mail(
 									$admin_email,
 									wcj_handle_replacements(
@@ -966,23 +949,11 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 					wp_safe_redirect( admin_url() );
 					return; // Traversal attempt.
 				}
-				if ( true === wcj_is_hpos_enabled() ) {
-					if ( isset( $_GET['id'] ) && isset( $_GET['wcj_checkout_file_number'] ) ) {
-						$order_id = isset( $_GET['id'] ) ? sanitize_text_field( wp_unslash( $_GET['id'] ) ) : ''; //phpcs:ignore WordPress.Security.NonceVerification
-						$order    = wcj_get_order( $order_id );
-						if ( $order && false !== $order ) {
-
-							$file_name = $order->get_meta( '_wcj_checkout_files_upload_real_name_' . sanitize_text_field( wp_unslash( $_GET['wcj_checkout_file_number'] ) ) );
-							if ( wcj_is_user_role( 'administrator' ) || is_shop_manager() ) {
-								WC_Download_Handler::download_file_force( $tmp_file_name, $file_name );
-							}
-						}
-					}
-				} elseif ( isset( $_GET['post'] ) && isset( $_GET['wcj_checkout_file_number'] ) ) {
-						$file_name = get_post_meta( sanitize_text_field( wp_unslash( $_GET['post'] ) ), '_wcj_checkout_files_upload_real_name_' . sanitize_text_field( wp_unslash( $_GET['wcj_checkout_file_number'] ) ), true );
-					if ( wcj_is_user_role( 'administrator' ) || is_shop_manager() ) {
-						WC_Download_Handler::download_file_force( $tmp_file_name, $file_name );
-					}
+				$order_id = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : ( isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0 ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$file_num = isset( $_GET['wcj_checkout_file_number'] ) ? absint( $_GET['wcj_checkout_file_number'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				if ( $order_id && $file_num && ( wcj_is_user_role( 'administrator' ) || is_shop_manager() ) ) {
+					$file_name = $this->get_order_file_meta( $order_id, '_wcj_checkout_files_upload_real_name_' . $file_num );
+					WC_Download_Handler::download_file_force( $tmp_file_name, $file_name );
 				}
 			}
 			// Admin all files delete.
@@ -994,19 +965,11 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 					return;
 				}
 
-				$order_id = sanitize_text_field( wp_unslash( $_GET['wcj_download_checkout_file_admin_delete_all'] ) );
-				$order    = wcj_get_order( $order_id );
-				if ( true === wcj_is_hpos_enabled() && $order && false !== $order ) {
-					$total_files = $order->get_meta( '_wcj_checkout_files_total_files' );
-				} else {
-					$total_files = get_post_meta( $order_id, '_wcj_checkout_files_total_files', true );
-				}
+				$order_id    = absint( $_GET['wcj_download_checkout_file_admin_delete_all'] );
+				$order       = wc_get_order( $order_id );
+				$total_files = absint( $this->get_order_file_meta( $order, '_wcj_checkout_files_total_files' ) );
 				for ( $i = 1; $i <= $total_files; $i++ ) {
-					if ( true === wcj_is_hpos_enabled() && $order && false !== $order ) {
-						$order_file_name = $order->get_meta( '_wcj_checkout_files_upload_' . $i );
-					} else {
-						$order_file_name = get_post_meta( $order_id, '_wcj_checkout_files_upload_' . $i, true );
-					}
+					$order_file_name = $this->get_order_file_meta( $order, '_wcj_checkout_files_upload_' . $i );
 					if ( '' !== $order_file_name ) {
 						$tmp_file_name = wcj_get_wcj_uploads_dir( 'checkout_files_upload' ) . '/' . sanitize_file_name( wp_unslash( $order_file_name ) );
 
@@ -1019,28 +982,19 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 							wp_delete_file( $tmp_file_name );
 						}
 					}
-					if ( true === wcj_is_hpos_enabled() && $order && false !== $order ) {
-						$order->delete_meta_data( '_wcj_checkout_files_upload_' . $i );
-						$order->delete_meta_data( '_wcj_checkout_files_upload_real_name_' . $i );
-					} else {
-						delete_post_meta( $order_id, '_wcj_checkout_files_upload_' . $i );
-						delete_post_meta( $order_id, '_wcj_checkout_files_upload_real_name_' . $i );
-					}
+					$this->delete_order_file_meta( $order, '_wcj_checkout_files_upload_' . $i );
+					$this->delete_order_file_meta( $order, '_wcj_checkout_files_upload_real_name_' . $i );
 				}
-				if ( true === wcj_is_hpos_enabled() && $order && false !== $order ) {
-					$order->delete_meta_data( '_wcj_checkout_files_total_files' );
-					$order->save();
-				} else {
-					delete_post_meta( $order_id, '_wcj_checkout_files_total_files' );
-				}
+				$this->delete_order_file_meta( $order, '_wcj_checkout_files_total_files' );
+				$this->save_order_if_hpos( $order );
 				wp_safe_redirect( remove_query_arg( 'wcj_download_checkout_file_admin_delete_all' ) );
 				exit;
 			}
 			// User file download.
 			if ( isset( $_GET['wcj_download_checkout_file'] ) && isset( $_GET['_wpnonce'] ) && ( false !== wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'wcj_download_checkout_file' ) ) ) {
-				$i = sanitize_text_field( wp_unslash( $_GET['wcj_download_checkout_file'] ) );
+				$i = absint( $_GET['wcj_download_checkout_file'] );
 				if ( ! empty( $_GET['wcj_download_checkout_file_order_id'] ) ) {
-					$order_id = sanitize_text_field( wp_unslash( $_GET['wcj_download_checkout_file_order_id'] ) );
+					$order_id = absint( $_GET['wcj_download_checkout_file_order_id'] );
 					$order    = wcj_get_order( $order_id );
 					if ( ! $order ) {
 						return;
@@ -1053,20 +1007,24 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 					} elseif ( ! wcj_is_user_logged_in() || $order->get_customer_id() !== wcj_get_current_user_id() ) {
 						return;
 					}
-					if ( true === wcj_is_hpos_enabled() && $order && false !== $order ) {
-						$order_file_name = $order->get_meta( '_wcj_checkout_files_upload_' . $i );
-						$file_name       = $order->get_meta( '_wcj_checkout_files_upload_real_name_' . $i );
-					} else {
-						$order_file_name = get_post_meta( $order_id, '_wcj_checkout_files_upload_' . $i, true );
-						$file_name       = get_post_meta( $order_id, '_wcj_checkout_files_upload_real_name_' . $i, true );
-					}
-					$tmp_file_name = wcj_get_wcj_uploads_dir( 'checkout_files_upload' ) . '/' . $order_file_name;
+					$order_file_name = $this->get_order_file_meta( $order, '_wcj_checkout_files_upload_' . $i );
+					$file_name       = $this->get_order_file_meta( $order, '_wcj_checkout_files_upload_real_name_' . $i );
+					$base_path       = realpath( wcj_get_wcj_uploads_dir( 'checkout_files_upload' ) );
+					$tmp_file_name   = wcj_get_wcj_uploads_dir( 'checkout_files_upload' ) . '/' . sanitize_file_name( wp_unslash( $order_file_name ) );
 				} else {
-					$session_data  = wcj_session_get( 'wcj_checkout_files_upload_' . $i );
+					$session_data = wcj_session_get( 'wcj_checkout_files_upload_' . $i );
+					if ( ! is_array( $session_data ) || empty( $session_data['tmp_name'] ) || empty( $session_data['name'] ) ) {
+						return;
+					}
+					$base_path     = realpath( wcj_get_wcj_uploads_dir( 'temp' ) );
 					$tmp_file_name = $session_data['tmp_name'];
 					$file_name     = $session_data['name'];
 				}
-				WC_Download_Handler::download_file_force( $tmp_file_name, $file_name );
+				$real_file_path = realpath( $tmp_file_name );
+				if ( false === $base_path || false === $real_file_path || 0 !== strpos( $real_file_path, trailingslashit( $base_path ) ) ) {
+					return;
+				}
+				WC_Download_Handler::download_file_force( $real_file_path, sanitize_file_name( wp_unslash( $file_name ) ) );
 			}
 		}
 
@@ -1251,22 +1209,19 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 		 * @param int    $order_id defines the order_id.
 		 */
 		public function maybe_get_image( $link, $i, $order_id = 0 ) {
-			$wpnonce = isset( $_REQUEST['wcj-checkout-files-upload-nonce'] ) ? wp_verify_nonce( sanitize_key( $_REQUEST['wcj-checkout-files-upload-nonce'] ), 'wcj-checkout-files-upload-nonce' ) : false;
+			$nonce   = isset( $_REQUEST['wcj-checkout-files-upload-nonce'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['wcj-checkout-files-upload-nonce'] ) ) : '';
+			$wpnonce = wp_verify_nonce( $nonce, 'wcj-checkout-files-upload-nonce' );
 			if ( 'yes' === wcj_get_option( 'wcj_checkout_files_upload_form_template_field_show_images', 'no' ) ) {
 				$order = wcj_get_order( $order_id );
 				if ( $wpnonce && 0 !== $order_id && isset( $_GET['key'] ) && ( $order ) && $order->key_is_valid( sanitize_text_field( wp_unslash( $_GET['key'] ) ) ) ) {
-					if ( true === wcj_is_hpos_enabled() && $order && false !== $order ) {
-						$order_file_name = $order->get_meta( '_wcj_checkout_files_upload_' . $i );
-					} else {
-						$order_file_name = get_post_meta( $order_id, '_wcj_checkout_files_upload_' . $i, true );
-					}
+					$order_file_name = $this->get_order_file_meta( $order, '_wcj_checkout_files_upload_' . $i );
 					$tmp_file_name = wcj_get_wcj_uploads_dir( 'checkout_files_upload' ) . '/' . $order_file_name;
 				} else {
-					$session_data  = wcj_session_get( 'wcj_checkout_files_upload_' . $i );
-					$tmp_file_name = $session_data['tmp_name'];
+					$session_data  = (array) wcj_session_get( 'wcj_checkout_files_upload_' . $i );
+					$tmp_file_name = isset( $session_data['tmp_name'] ) ? $session_data['tmp_name'] : '';
 				}
 				if ( file_exists( $tmp_file_name ) && is_array( getimagesize( $tmp_file_name ) ) ) {
-					return '<img style="' . wcj_get_option( 'wcj_checkout_files_upload_form_template_field_image_style', 'width:64px;' ) . '" src="' . $link . '"> ';
+					return '<img style="' . esc_attr( wcj_get_option( 'wcj_checkout_files_upload_form_template_field_image_style', 'width:64px;' ) ) . '" src="' . esc_url( $link ) . '"> ';
 				}
 			}
 			return '';
@@ -1318,7 +1273,7 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 						'wcj_download_checkout_file_order_id' => $order_id,
 					)
 				);
-				$field_html  = '<a href="' . $link . '">' . $this->maybe_get_image( $link, $i, $order_id ) . $file_name . '</a>';
+				$field_html  = '<a href="' . esc_url( $link ) . '">' . $this->maybe_get_image( $link, $i, $order_id ) . esc_html( $file_name ) . '</a>';
 				$button_html = '<input type="submit"' .
 					' class="button"' .
 					' style="width:100%;"' .
@@ -1349,7 +1304,7 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 		/**
 		 * Add_files_upload_form_to_thankyou_and_myaccount_page.
 		 *
-		 * @version 7.1.4
+		 * @version 8.1.0
 		 * @since   2.5.0
 		 * @param int $order_id defines the order_id.
 		 */
@@ -1363,14 +1318,7 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 						( 'yes' === wcj_get_option( 'wcj_checkout_files_upload_add_to_thankyou_' . $i, 'no' ) && 'woocommerce_thankyou' === $current_filter ) ||
 						( 'yes' === wcj_get_option( 'wcj_checkout_files_upload_add_to_myaccount_' . $i, 'no' ) && 'woocommerce_view_order' === $current_filter )
 					) {
-						if ( true === wcj_is_hpos_enabled() ) {
-							$order = wcj_get_order( $order_id );
-							if ( $order && false !== $order ) {
-								$file_name = $order->get_meta( '_wcj_checkout_files_upload_real_name_' . $i );
-							}
-						} else {
-							$file_name = get_post_meta( $order_id, '_wcj_checkout_files_upload_real_name_' . $i, true );
-						}
+						$file_name = $this->get_order_file_meta( $order_id, '_wcj_checkout_files_upload_real_name_' . $i );
 						$html .= $this->get_the_form( $i, $file_name, $order_id );
 					}
 				}

--- a/includes/class-wcj-compatibility-status.php
+++ b/includes/class-wcj-compatibility-status.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Compatibility Status
  *
- * @version 8.0.2
+ * @version 8.1.0
  * @since   8.0.2
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -118,65 +118,104 @@ if ( ! class_exists( 'WCJ_Compatibility_Status' ) ) :
 		 * @return array
 		 */
 		protected function get_active_checkout_modules() {
+			$conditional_fields_note = defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '9.9.0', '>=' )
+				? __( 'Text, select, checkbox, and radio-as-select fields support cart-aware visibility. Other types and Classic placement sections remain Classic-only.', 'woocommerce-jetpack' )
+				: __( 'Conditioned fields require WooCommerce 9.9 or later and are skipped in Blocks on this WooCommerce version. Unconditioned supported types remain available.', 'woocommerce-jetpack' );
 			$modules = array(
 				array(
 					'id'    => 'checkout_fees',
 					'label' => __( 'Checkout Fees', 'woocommerce-jetpack' ),
+					'status' => __( 'Partial', 'woocommerce-jetpack' ),
 					'note'  => __( 'Simple fixed and percentage fees are maintained for Blocks; checkout-field-conditional fees remain a Classic Checkout/staging item.', 'woocommerce-jetpack' ),
 				),
 				array(
 					'id'    => 'checkout_custom_fields',
 					'label' => __( 'Checkout Custom Fields', 'woocommerce-jetpack' ),
-					'note'  => __( 'Basic fields are Blocks-aware; richer visibility and placement rules should be confirmed on Classic Checkout or in staging.', 'woocommerce-jetpack' ),
+					'status' => __( 'Supported types', 'woocommerce-jetpack' ),
+					'note'  => $conditional_fields_note,
 				),
 				array(
 					'id'    => 'checkout_files_upload',
 					'label' => __( 'Checkout Files Upload', 'woocommerce-jetpack' ),
-					'note'  => __( 'Store API order attachment paths are maintained; file upload placement and validation should be tested with the exact checkout flow.', 'woocommerce-jetpack' ),
+					'status' => __( 'Classic-only input', 'woocommerce-jetpack' ),
+					'note'  => __( 'Checkout file inputs require Classic Checkout. Existing post-order account and order-association paths remain available where configured.', 'woocommerce-jetpack' ),
 				),
 				array(
 					'id'    => 'product_addons',
 					'label' => __( 'Product Addons', 'woocommerce-jetpack' ),
-					'note'  => __( 'Addon choices now use safer submitted values and structured cart data; test add-to-cart, checkout, and order meta with your enabled tier limits.', 'woocommerce-jetpack' ),
+					'status' => __( 'Cart and order supported', 'woocommerce-jetpack' ),
+					'note'  => __( 'Addon inputs render on product pages and their cart data is persisted through Classic and Blocks checkout. They are not checkout form fields.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'     => 'product_input_fields',
+					'label'  => __( 'Product Input Fields', 'woocommerce-jetpack' ),
+					'status' => __( 'Cart and order supported', 'woocommerce-jetpack' ),
+					'note'   => __( 'Product-page values, including supported files, travel with cart items through Classic and Blocks checkout. They are not checkout form fields.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'     => 'payment_gateways_fees',
+					'label'  => __( 'Gateway Fees and Discounts', 'woocommerce-jetpack' ),
+					'status' => __( 'Supported', 'woocommerce-jetpack' ),
+					'note'   => __( 'Uses the WooCommerce chosen-payment session and cart fee API. Test guest and signed-in gateway switching with every configured rule.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'     => 'checkout_custom_info',
+					'label'  => __( 'Checkout Custom Info', 'woocommerce-jetpack' ),
+					'status' => __( 'Classic-only', 'woocommerce-jetpack' ),
+					'note'   => __( 'Shortcode checkout placement hooks do not have equivalent supported Checkout block positions.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'     => 'more_button_labels',
+					'label'  => __( 'Checkout button labels', 'woocommerce-jetpack' ),
+					'status' => __( 'Classic-only', 'woocommerce-jetpack' ),
+					'note'   => __( 'Classic button-label filters do not change the Checkout block submit button.', 'woocommerce-jetpack' ),
 				),
 				array(
 					'id'    => 'eu_vat_number',
 					'label' => __( 'EU VAT Number', 'woocommerce-jetpack' ),
+					'status' => __( 'Needs exact-flow testing', 'woocommerce-jetpack' ),
 					'note'  => __( 'VAT capture and validation remain checkout-flow sensitive; Classic Checkout is recommended unless the exact Blocks flow has been staged.', 'woocommerce-jetpack' ),
 				),
 				array(
 					'id'    => 'payment_gateways',
 					'label' => __( 'Custom Payment Gateways', 'woocommerce-jetpack' ),
+					'status' => __( 'Needs exact-flow testing', 'woocommerce-jetpack' ),
 					'note'  => __( 'Gateway visibility and order data should be checked with the active checkout architecture before release.', 'woocommerce-jetpack' ),
 				),
 				array(
 					'id'    => 'payment_gateways_by_country',
 					'label' => __( 'Payment Gateways by Country', 'woocommerce-jetpack' ),
+					'status' => __( 'Needs exact-flow testing', 'woocommerce-jetpack' ),
 					'note'  => __( 'Gateway filters depend on checkout customer data; test the live shipping/billing scenario in staging.', 'woocommerce-jetpack' ),
 				),
 				array(
 					'id'    => 'payment_gateways_by_currency',
 					'label' => __( 'Payment Gateways by Currency', 'woocommerce-jetpack' ),
+					'status' => __( 'Needs exact-flow testing', 'woocommerce-jetpack' ),
 					'note'  => __( 'Gateway filters depend on the active currency; test the currency switcher and checkout together.', 'woocommerce-jetpack' ),
 				),
 				array(
 					'id'    => 'payment_gateways_by_shipping',
 					'label' => __( 'Payment Gateways by Shipping', 'woocommerce-jetpack' ),
+					'status' => __( 'Needs exact-flow testing', 'woocommerce-jetpack' ),
 					'note'  => __( 'Gateway filters depend on selected shipping methods; test after shipping rates are available in the checkout flow.', 'woocommerce-jetpack' ),
 				),
 				array(
 					'id'    => 'payment_gateways_by_user_role',
 					'label' => __( 'Payment Gateways by User Role', 'woocommerce-jetpack' ),
+					'status' => __( 'Needs exact-flow testing', 'woocommerce-jetpack' ),
 					'note'  => __( 'Gateway filters depend on customer session state; test guest and signed-in roles separately.', 'woocommerce-jetpack' ),
 				),
 				array(
 					'id'    => 'payment_gateways_min_max',
 					'label' => __( 'Gateways Min/Max Amounts', 'woocommerce-jetpack' ),
+					'status' => __( 'Needs exact-flow testing', 'woocommerce-jetpack' ),
 					'note'  => __( 'Gateway filters depend on recalculated cart totals; test below, inside, and above each configured threshold.', 'woocommerce-jetpack' ),
 				),
 				array(
 					'id'    => 'payment_gateways_per_category',
 					'label' => __( 'Gateways by Product or Category', 'woocommerce-jetpack' ),
+					'status' => __( 'Needs exact-flow testing', 'woocommerce-jetpack' ),
 					'note'  => __( 'Gateway filters depend on cart contents; test carts with matching and non-matching products/categories.', 'woocommerce-jetpack' ),
 				),
 			);
@@ -196,17 +235,38 @@ if ( ! class_exists( 'WCJ_Compatibility_Status' ) ) :
 				array(
 					'id'    => 'order_numbers',
 					'label' => __( 'Order Numbers', 'woocommerce-jetpack' ),
-					'note'  => __( 'Order-number reads and writes now prefer WooCommerce order meta APIs with a legacy fallback.', 'woocommerce-jetpack' ),
+					'status' => __( 'Order CRUD', 'woocommerce-jetpack' ),
+					'note'  => __( 'Creation, display, search, and renumeration use maintained WooCommerce order paths in the audited workflows.', 'woocommerce-jetpack' ),
 				),
 				array(
 					'id'    => 'pdf_invoicing',
 					'label' => __( 'PDF Invoicing', 'woocommerce-jetpack' ),
-					'note'  => __( 'Order-owner checks now read the customer through WooCommerce order APIs with a legacy fallback.', 'woocommerce-jetpack' ),
+					'status' => __( 'Order CRUD', 'woocommerce-jetpack' ),
+					'note'  => __( 'Invoice document metadata, order-owner checks, admin numbering, and audited report fields use WooCommerce order APIs.', 'woocommerce-jetpack' ),
 				),
 				array(
 					'id'    => 'checkout_files_upload',
 					'label' => __( 'Checkout Files Upload', 'woocommerce-jetpack' ),
-					'note'  => __( 'Order attachment paths should be checked against the store\'s upload hooks and order emails.', 'woocommerce-jetpack' ),
+					'status' => __( 'Order CRUD', 'woocommerce-jetpack' ),
+					'note'  => __( 'Order attachment, admin, download, deletion, email, and account metadata use WooCommerce order APIs in audited paths.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'     => 'checkout_custom_fields',
+					'label'  => __( 'Checkout Custom Fields', 'woocommerce-jetpack' ),
+					'status' => __( 'Order CRUD', 'woocommerce-jetpack' ),
+					'note'   => __( 'Classic and Blocks field updates are batched on the order object and saved once per logical update.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'     => 'product_addons',
+					'label'  => __( 'Product Addons', 'woocommerce-jetpack' ),
+					'status' => __( 'Order-item CRUD', 'woocommerce-jetpack' ),
+					'note'   => __( 'Addon values are persisted while WooCommerce creates the order line item, without legacy item properties or extra saves.', 'woocommerce-jetpack' ),
+				),
+				array(
+					'id'     => 'product_input_fields',
+					'label'  => __( 'Product Input Fields', 'woocommerce-jetpack' ),
+					'status' => __( 'Order-item CRUD', 'woocommerce-jetpack' ),
+					'note'   => __( 'Input values and file references use WooCommerce order-item APIs in maintained checkout paths.', 'woocommerce-jetpack' ),
 				),
 			);
 
@@ -216,7 +276,7 @@ if ( ! class_exists( 'WCJ_Compatibility_Status' ) ) :
 		/**
 		 * Filters module definitions to active modules only.
 		 *
-		 * @version 8.0.2
+		 * @version 8.1.0
 		 * @since   8.0.2
 		 * @param array $modules defines module definitions.
 		 * @return array
@@ -265,13 +325,14 @@ if ( ! class_exists( 'WCJ_Compatibility_Status' ) ) :
 			echo '<div class="notice ' . esc_attr( $notice_class ) . ' wcj-compatibility-status">';
 			echo '<p><strong>' . esc_html( $title ) . '</strong></p>';
 			echo '<p>' . esc_html( $intro ) . '</p>';
-			echo '<ul style="list-style:disc;margin-left:20px;">';
+			echo '<table class="widefat striped" style="margin:8px 0 12px;max-width:1100px;">';
+			echo '<thead><tr><th>' . esc_html__( 'Module', 'woocommerce-jetpack' ) . '</th><th>' . esc_html__( 'Status', 'woocommerce-jetpack' ) . '</th><th>' . esc_html__( 'Guidance', 'woocommerce-jetpack' ) . '</th></tr></thead><tbody>';
 
 			foreach ( $modules as $module ) {
-				echo '<li><strong>' . esc_html( $module['label'] ) . ':</strong> ' . esc_html( $module['note'] ) . '</li>';
+				echo '<tr><td><strong>' . esc_html( $module['label'] ) . '</strong></td><td>' . esc_html( isset( $module['status'] ) ? $module['status'] : __( 'Review', 'woocommerce-jetpack' ) ) . '</td><td>' . esc_html( $module['note'] ) . '</td></tr>';
 			}
 
-			echo '</ul>';
+			echo '</tbody></table>';
 			echo '<p>' . esc_html( $this->get_tier_note() ) . '</p>';
 			echo '</div>';
 		}

--- a/includes/class-wcj-order-numbers.php
+++ b/includes/class-wcj-order-numbers.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Order Numbers
  *
- * @version 7.3.0
+ * @version 8.1.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
  */
@@ -22,9 +22,8 @@ if ( ! class_exists( 'WCJ_Order_Numbers' ) ) :
 		/**
 		 * Constructor.
 		 *
-		 * @version 7.3.0
+		 * @version 8.1.0
 		 * @todo    (maybe) rename "Orders Renumerate" to "Renumerate orders"
-		 * @todo    (maybe) use `woocommerce_new_order` hook instead of `wp_insert_post`
 		 */
 		public function __construct() {
 
@@ -46,10 +45,10 @@ if ( ! class_exists( 'WCJ_Order_Numbers' ) ) :
 
 			if ( $this->is_enabled() ) {
 				// Add & display custom order number.
-				if ( true === wcj_is_hpos_enabled() ) {
-					add_action( 'woocommerce_new_order', array( $this, 'add_new_order_number' ), PHP_INT_MAX );
-				} else {
+				if ( WCJ_IS_WC_VERSION_BELOW_3 ) {
 					add_action( 'wp_insert_post', array( $this, 'add_new_order_number' ), PHP_INT_MAX );
+				} else {
+					add_action( 'woocommerce_new_order', array( $this, 'add_new_order_number' ), PHP_INT_MAX );
 				}
 				add_filter( 'woocommerce_order_number', array( $this, 'display_order_number' ), PHP_INT_MAX, 2 );
 				// Order tracking.
@@ -209,19 +208,16 @@ if ( ! class_exists( 'WCJ_Order_Numbers' ) ) :
 		/**
 		 * Maybe_add_meta_box.
 		 *
-		 * @version 7.1.4
+		 * @version 8.1.0
 		 * @since   3.5.0
 		 * @todo    re-think if setting number for yet not-numbered order should be allowed (i.e. do not check for `( '' !== get_post_meta( $post->ID, '_wcj_order_number', true ) )`)
 		 * @param string         $post_type defines the post_type.
 		 * @param string | array $post defines the post.
 		 */
 		public function maybe_add_meta_box( $post_type, $post ) {
-			$order            = wcj_get_order( $post->ID );
-			$wcj_order_number = ( isset( $order ) && false !== $order ? $order->get_meta( '_wcj_order_number' ) : '' );
-			if ( true === wcj_is_hpos_enabled() && $wcj_order_number ) {
+			$order = $post instanceof WC_Order ? $post : wc_get_order( isset( $post->ID ) ? $post->ID : 0 );
+			if ( $order && '' !== $order->get_meta( '_wcj_order_number' ) ) {
 				parent::add_meta_box();
-			} elseif ( '' !== $this->get_booster_order_meta( $post->ID, '_wcj_order_number' ) ) {
-					parent::add_meta_box();
 			}
 		}
 
@@ -353,20 +349,36 @@ if ( ! class_exists( 'WCJ_Order_Numbers' ) ) :
 			$offset     = 0;
 			$block_size = 512;
 			while ( true ) {
-				$args = array(
-					'post_type'      => 'shop_order',
-					'post_status'    => 'any',
-					'posts_per_page' => $block_size,
-					'orderby'        => 'ID',
-					'order'          => 'DESC',
-					'offset'         => $offset,
-					'fields'         => 'ids',
-				);
-				$loop = new WP_Query( $args );
-				if ( ! $loop->have_posts() ) {
+				if ( function_exists( 'wc_get_orders' ) ) {
+					$order_ids = wc_get_orders(
+						array(
+							'type'    => array( 'shop_order' ),
+							'status'  => 'any',
+							'limit'   => $block_size,
+							'orderby' => 'id',
+							'order'   => 'DESC',
+							'offset'  => $offset,
+							'return'  => 'ids',
+						)
+					);
+				} else {
+					$loop = new WP_Query(
+						array(
+							'post_type'      => 'shop_order',
+							'post_status'    => 'any',
+							'posts_per_page' => $block_size,
+							'orderby'        => 'ID',
+							'order'          => 'DESC',
+							'offset'         => $offset,
+							'fields'         => 'ids',
+						)
+					);
+					$order_ids = $loop->posts;
+				}
+				if ( empty( $order_ids ) ) {
 					break;
 				}
-				foreach ( $loop->posts as $_order_id ) {
+				foreach ( $order_ids as $_order_id ) {
 					$_order        = wc_get_order( $_order_id );
 					$_order_number = $this->display_order_number( $_order_id, $_order );
 					if ( $_order_number === $order_number ) {
@@ -381,17 +393,13 @@ if ( ! class_exists( 'WCJ_Order_Numbers' ) ) :
 		/**
 		 * Display order number.
 		 *
-		 * @version 7.1.4
+		 * @version 8.1.0
 		 * @param int            $order_number defines the order_number.
 		 * @param string | array $order defines the order.
 		 */
 		public function display_order_number( $order_number, $order ) {
 			$order_id = wcj_get_order_id( $order );
-			if ( true === wcj_is_hpos_enabled() ) {
-				$order_number_meta = $order->get_meta( '_wcj_order_number' );
-			} else {
-				$order_number_meta = get_post_meta( $order_id, '_wcj_order_number', true );
-			}
+			$order_number_meta = is_callable( array( $order, 'get_meta' ) ) ? $order->get_meta( '_wcj_order_number' ) : $this->get_booster_order_meta( $order_id, '_wcj_order_number' );
 			if ( '' === $order_number_meta || 'no' === wcj_get_option( 'wcj_order_number_sequential_enabled', 'yes' ) ) {
 				$order_number_meta = $order_id;
 			}
@@ -464,10 +472,10 @@ if ( ! class_exists( 'WCJ_Order_Numbers' ) ) :
 		 * @param int $order_id defines the order_id.
 		 */
 		public function add_new_order_number( $order_id ) {
-			if ( true === wcj_is_hpos_enabled() ) {
-				$this->add_order_number_meta_hpos( $order_id, false );
-			} else {
+			if ( WCJ_IS_WC_VERSION_BELOW_3 ) {
 				$this->add_order_number_meta( $order_id, false );
+			} else {
+				$this->add_order_number_meta_hpos( $order_id, false );
 			}
 		}
 
@@ -570,9 +578,9 @@ if ( ! class_exists( 'WCJ_Order_Numbers' ) ) :
 
 
 		/**
-		 * Add/update order_number meta to order HPOS.
+		 * Add/update order number meta through WooCommerce order CRUD.
 		 *
-		 * @version 7.1.9
+		 * @version 8.1.0
 		 * @todo    (maybe) save order ID instead of `$current_order_number = ''` (if `'no' === wcj_get_option( 'wcj_order_number_sequential_enabled', 'yes' )`)
 		 * @param int  $order_id defines the order_id.
 		 * @param bool $do_overwrite defines the do_overwrite.
@@ -582,7 +590,8 @@ if ( ! class_exists( 'WCJ_Order_Numbers' ) ) :
 
 			if ( $order && false !== $order ) {
 
-				if ( 'shop_order' !== OrderUtil::get_order_type( $order_id ) || 'auto-draft' === $order->get_status() ) {
+				$order_type = class_exists( 'Automattic\\WooCommerce\\Utilities\\OrderUtil' ) ? OrderUtil::get_order_type( $order_id ) : $order->get_type();
+				if ( 'shop_order' !== $order_type || 'auto-draft' === $order->get_status() ) {
 					return;
 				}
 
@@ -630,7 +639,7 @@ if ( ! class_exists( 'WCJ_Order_Numbers' ) ) :
 		/**
 		 * Renumerate orders function.
 		 *
-		 * @version 7.1.4
+		 * @version 8.1.0
 		 * @todo    renumerate in date range only
 		 * @todo    (maybe) selectable `post_status`
 		 * @todo    (maybe) set default value for `wcj_order_numbers_renumerate_tool_orderby` to `ID` (instead of `date`)
@@ -643,26 +652,22 @@ if ( ! class_exists( 'WCJ_Order_Numbers' ) ) :
 			$block_size = 512;
 			while ( true ) {
 
-				if ( true === wcj_is_hpos_enabled() ) {
-
+				if ( function_exists( 'wc_get_orders' ) ) {
 					$args  = array(
-						'type'           => 'shop_order',
+						'type'           => array( 'shop_order' ),
 						'status'         => 'any',
-						'posts_per_page' => $block_size,
+						'limit'          => $block_size,
 						'orderby'        => wcj_get_option( 'wcj_order_numbers_renumerate_tool_orderby', 'date' ),
 						'order'          => wcj_get_option( 'wcj_order_numbers_renumerate_tool_order', 'ASC' ),
 						'offset'         => $offset,
 						'fields'         => 'ids',
 					);
-					$order = wc_get_orders( $args );
-					if ( ! $order ) {
+					$order_ids = wc_get_orders( $args );
+					if ( ! $order_ids ) {
 						break;
 					}
-					$i = 0;
-					foreach ( $order as $order_id ) {
-
+					foreach ( $order_ids as $order_id ) {
 						$this->add_order_number_meta_hpos( $order_id, true );
-						++$i;
 					}
 				} else {
 

--- a/includes/class-wcj-payment-gateways-fees.php
+++ b/includes/class-wcj-payment-gateways-fees.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Gateways Fees and Discounts
  *
- * @version 7.3.0
+ * @version 8.1.0
  * @since   2.2.2
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -25,6 +25,13 @@ if ( ! class_exists( 'WCJ_Payment_Gateways_Fees' ) ) :
 		 * @var array
 		 */
 		public $defaults = array();
+
+		/**
+		 * Request-scoped cart product and variation IDs.
+		 *
+		 * @var array|null
+		 */
+		private $cart_product_ids = null;
 
 		/**
 		 * Constructor.
@@ -150,20 +157,23 @@ if ( ! class_exists( 'WCJ_Payment_Gateways_Fees' ) ) :
 		/**
 		 * Get_current_gateway.
 		 *
-		 * @version 5.6.8
+		 * @version 8.1.0
 		 * @since   3.3.0
 		 */
 		public function get_current_gateway() {
 			$gateway = '';
 			// phpcs:disable WordPress.Security.NonceVerification
-			if ( isset( $_GET['wc-api'] ) && 'WC_Gateway_PayPal_Express_AngellEYE' === $_GET['wc-api'] ) {
+			$wc_api        = isset( $_GET['wc-api'] ) ? sanitize_text_field( wp_unslash( $_GET['wc-api'] ) ) : '';
+			$wc_ajax       = isset( $_GET['wc-ajax'] ) ? sanitize_text_field( wp_unslash( $_GET['wc-ajax'] ) ) : '';
+			$startcheckout = isset( $_GET['startcheckout'] ) ? sanitize_text_field( wp_unslash( $_GET['startcheckout'] ) ) : '';
+			if ( 'WC_Gateway_PayPal_Express_AngellEYE' === $wc_api ) {
 				$gateway = 'paypal_express'; // PayPal for WooCommerce (By Angell EYE).
 			} elseif (
-				( isset( $_GET['wc-ajax'] ) && 'wc_ppec_generate_cart' === $_GET['wc-ajax'] ) ||
-				( isset( $_GET['startcheckout'] ) && 'true' === $_GET['startcheckout'] )
+				'wc_ppec_generate_cart' === $wc_ajax ||
+				'true' === $startcheckout
 			) {
 				$gateway = 'ppec_paypal'; // WooCommerce PayPal Express Checkout Payment Gateway (By WooCommerce).
-			} else {
+			} elseif ( function_exists( 'WC' ) && WC()->session ) {
 				$gateway = WC()->session->get( 'chosen_payment_method' );
 			}
 			// phpcs:enable WordPress.Security.NonceVerification
@@ -176,49 +186,62 @@ if ( ! class_exists( 'WCJ_Payment_Gateways_Fees' ) ) :
 			) {
 				$gateways = WC()->payment_gateways->get_available_payment_gateways();
 				if ( $gateways ) {
-					foreach ( $gateways as $gateway ) {
-						if ( 'yes' === $gateway->enabled ) {
-							WC()->session->set( 'chosen_payment_method', $gateway->id );
+					foreach ( $gateways as $available_gateway ) {
+						if ( 'yes' === $available_gateway->enabled ) {
+							WC()->session->set( 'chosen_payment_method', $available_gateway->id );
 							$gateway = WC()->session->get( 'chosen_payment_method' );
 							break;
 						}
 					}
 				}
 			}
-			return $gateway;
+			return is_string( $gateway ) ? $gateway : '';
+		}
+
+		/**
+		 * Get product and variation IDs from the cart once per request.
+		 *
+		 * @param WC_Cart $cart Cart object.
+		 * @return array
+		 */
+		private function get_cart_product_ids( $cart ) {
+			if ( null !== $this->cart_product_ids ) {
+				return $this->cart_product_ids;
+			}
+			$this->cart_product_ids = array();
+			foreach ( $cart->get_cart() as $item ) {
+				if ( ! empty( $item['product_id'] ) ) {
+					$this->cart_product_ids[] = (string) $item['product_id'];
+				}
+				if ( ! empty( $item['variation_id'] ) ) {
+					$this->cart_product_ids[] = (string) $item['variation_id'];
+				}
+			}
+			$this->cart_product_ids = array_values( array_unique( $this->cart_product_ids ) );
+			return $this->cart_product_ids;
 		}
 
 		/**
 		 * Check_cart_products.
 		 *
-		 * @version 3.8.0
+		 * @version 8.1.0
 		 * @since   3.7.0
 		 * @todo    add WPML support
-		 * @todo    add product variations
 		 * @todo    add product cats and tags
-		 * @param string $gateway defines the gateway.
+		 * @param string  $gateway Gateway ID.
+		 * @param WC_Cart $cart    Cart object.
 		 */
-		public function check_cart_products( $gateway ) {
-			$include_products = $this->wcj_get_option( 'include_products', $gateway );
+		public function check_cart_products( $gateway, $cart ) {
+			$product_ids      = $this->get_cart_product_ids( $cart );
+			$include_products = array_map( 'strval', (array) $this->wcj_get_option( 'include_products', $gateway ) );
 			if ( ! empty( $include_products ) ) {
-				$passed = false;
-				foreach ( WC()->cart->get_cart() as $item ) {
-					if ( in_array( $item['product_id'], $include_products, true ) ) {
-						$passed = true;
-						break;
-					}
-				}
-				if ( ! $passed ) {
+				if ( empty( array_intersect( $product_ids, $include_products ) ) ) {
 					return false;
 				}
 			}
-			$exclude_products = $this->wcj_get_option( 'exclude_products', $gateway );
-			if ( ! empty( $exclude_products ) ) {
-				foreach ( WC()->cart->get_cart() as $item ) {
-					if ( in_array( $item['product_id'], $exclude_products, true ) ) {
-						return false;
-					}
-				}
+			$exclude_products = array_map( 'strval', (array) $this->wcj_get_option( 'exclude_products', $gateway ) );
+			if ( ! empty( $exclude_products ) && ! empty( array_intersect( $product_ids, $exclude_products ) ) ) {
+				return false;
 			}
 			return true;
 		}
@@ -226,71 +249,84 @@ if ( ! class_exists( 'WCJ_Payment_Gateways_Fees' ) ) :
 		/**
 		 * Gateways_fees.
 		 *
-		 * @version 6.0.1
+		 * @version 8.1.0
+		 * @param WC_Cart|null $cart Cart passed by WooCommerce.
 		 */
-		public function gateways_fees() {
-			global $woocommerce;
-			$current_gateway = $this->get_current_gateway();
-			if ( strpos( $current_gateway, 'klarna' ) !== false && 'yes' === wcj_get_option( 'wcj_enable_payment_gateway_charge_discount', 'no' ) ) {
-				$current_gateway = 'klarna_payments';
-				$fee_value       = $this->wcj_get_option( 'value', $current_gateway );
+		public function gateways_fees( $cart = null ) {
+			$cart = $cart instanceof WC_Cart ? $cart : ( function_exists( 'WC' ) ? WC()->cart : null );
+			if ( ! $cart || ! function_exists( 'WC' ) || ! WC()->session ) {
+				return;
 			}
-			if ( '' !== $current_gateway ) {
-				$fee_text        = do_shortcode( $this->wcj_get_option( 'text', $current_gateway ) );
-				$min_cart_amount = $this->wcj_get_option( 'min_cart_amount', $current_gateway );
-				$max_cart_amount = $this->wcj_get_option( 'max_cart_amount', $current_gateway );
-				// Multicurrency (Currency Switcher) module.
-				if ( w_c_j()->all_modules['multicurrency']->is_enabled() ) {
-					$min_cart_amount = w_c_j()->all_modules['multicurrency']->change_price( $min_cart_amount, null );
-					$max_cart_amount = w_c_j()->all_modules['multicurrency']->change_price( $max_cart_amount, null );
-				}
-				$total_in_cart  = ( 'no' === $this->wcj_get_option( 'exclude_shipping', $current_gateway ) ?
-					$woocommerce->cart->cart_contents_total + $woocommerce->cart->shipping_total :
-					$woocommerce->cart->cart_contents_total );
-				$total_in_cart += 'no' === $this->wcj_get_option( 'include_taxes', $current_gateway ) ? 0 : $woocommerce->cart->get_subtotal_tax() + $woocommerce->cart->get_shipping_tax();
-				if ( '' !== $fee_text && $total_in_cart >= $min_cart_amount && ( '0' === $max_cart_amount || $total_in_cart <= $max_cart_amount ) && $this->check_cart_products( $current_gateway ) ) {
-					$enable_user_wise_charge_discount = wcj_get_option( 'wcj_enable_payment_gateway_charge_discount_userwise' )[ $current_gateway ];
-					if ( 'yes' === $enable_user_wise_charge_discount ) {
-						if ( is_user_logged_in() ) {
-							global $current_user;
-							$user_role = $current_user->roles[0];
-						} else {
-							$user_role = 'guest';
-						}
-						$additional_discountby_user = wcj_get_option( 'wcj_gateways_fees_' . $user_role )[ $current_gateway ];
-						if ( $additional_discountby_user ) {
-							$fee_value = $additional_discountby_user;
-						}
+			if ( empty( $this->options ) || empty( $this->defaults ) ) {
+				$this->init_options();
+			}
+
+			$current_gateway = $this->get_current_gateway();
+			if ( '' === $current_gateway ) {
+				return;
+			}
+			if ( false !== strpos( $current_gateway, 'klarna' ) && 'yes' === wcj_get_option( 'wcj_enable_payment_gateway_charge_discount', 'no' ) ) {
+				$current_gateway = 'klarna_payments';
+			}
+
+			$fee_text        = do_shortcode( $this->wcj_get_option( 'text', $current_gateway ) );
+			$min_cart_amount = (float) $this->wcj_get_option( 'min_cart_amount', $current_gateway );
+			$max_cart_amount = (float) $this->wcj_get_option( 'max_cart_amount', $current_gateway );
+			if ( '' === $fee_text ) {
+				return;
+			}
+
+			// Multicurrency (Currency Switcher) module.
+			$multicurrency_enabled = isset( w_c_j()->all_modules['multicurrency'] ) && w_c_j()->all_modules['multicurrency']->is_enabled();
+			if ( $multicurrency_enabled ) {
+				$min_cart_amount = w_c_j()->all_modules['multicurrency']->change_price( $min_cart_amount, null );
+				$max_cart_amount = w_c_j()->all_modules['multicurrency']->change_price( $max_cart_amount, null );
+			}
+			$total_in_cart  = ( 'no' === $this->wcj_get_option( 'exclude_shipping', $current_gateway ) ?
+				$cart->get_cart_contents_total() + $cart->get_shipping_total() :
+				$cart->get_cart_contents_total() );
+			$total_in_cart += 'no' === $this->wcj_get_option( 'include_taxes', $current_gateway ) ? 0 : $cart->get_subtotal_tax() + $cart->get_shipping_tax();
+			if ( $total_in_cart >= $min_cart_amount && ( 0.0 === $max_cart_amount || $total_in_cart <= $max_cart_amount ) && $this->check_cart_products( $current_gateway, $cart ) ) {
+				$userwise_options                  = (array) wcj_get_option( 'wcj_enable_payment_gateway_charge_discount_userwise', array() );
+				$enable_user_wise_charge_discount = isset( $userwise_options[ $current_gateway ] ) ? $userwise_options[ $current_gateway ] : 'no';
+				if ( 'yes' === $enable_user_wise_charge_discount ) {
+					if ( is_user_logged_in() ) {
+						$user      = wp_get_current_user();
+						$user_role = isset( $user->roles[0] ) ? $user->roles[0] : 'guest';
 					} else {
-						$fee_value = $this->wcj_get_option( 'value', $current_gateway );
+						$user_role = 'guest';
 					}
-					$fee_type         = $this->wcj_get_option( 'type', $current_gateway );
-					$final_fee_to_add = 0;
-					switch ( $fee_type ) {
-						case 'fixed':
-							// Multicurrency (Currency Switcher) module.
-							if ( w_c_j()->all_modules['multicurrency']->is_enabled() ) {
-								$fee_value = w_c_j()->all_modules['multicurrency']->change_price( $fee_value, null );
-							}
-							$final_fee_to_add = $fee_value;
-							break;
-						case 'percent':
-							$final_fee_to_add = ( $fee_value / 100 ) * $total_in_cart;
-							if ( 'yes' === $this->wcj_get_option( 'round', $current_gateway ) ) {
-								$final_fee_to_add = round( $final_fee_to_add, $this->wcj_get_option( 'round_precision', $current_gateway ) );
-							}
-							break;
-					}
-					if ( 0 !== $final_fee_to_add ) {
-						$taxable        = ( 'yes' === $this->wcj_get_option( 'is_taxable', $current_gateway ) );
-						$tax_class_name = '';
-						if ( $taxable ) {
-							$tax_class_id    = $this->wcj_get_option( 'tax_class_id', $current_gateway );
-							$tax_class_names = array_merge( array( '' ), WC_Tax::get_tax_classes() );
-							$tax_class_name  = $tax_class_names[ $tax_class_id ];
+					$role_values                = (array) wcj_get_option( 'wcj_gateways_fees_' . $user_role, array() );
+					$additional_discountby_user = isset( $role_values[ $current_gateway ] ) ? $role_values[ $current_gateway ] : '';
+					$fee_value                  = $additional_discountby_user ? $additional_discountby_user : $this->wcj_get_option( 'value', $current_gateway );
+				} else {
+					$fee_value = $this->wcj_get_option( 'value', $current_gateway );
+				}
+				$fee_type         = $this->wcj_get_option( 'type', $current_gateway );
+				$final_fee_to_add = 0;
+				switch ( $fee_type ) {
+					case 'fixed':
+						if ( $multicurrency_enabled ) {
+							$fee_value = w_c_j()->all_modules['multicurrency']->change_price( $fee_value, null );
 						}
-						$woocommerce->cart->add_fee( $fee_text, $final_fee_to_add, $taxable, $tax_class_name );
+						$final_fee_to_add = $fee_value;
+						break;
+					case 'percent':
+						$final_fee_to_add = ( $fee_value / 100 ) * $total_in_cart;
+						if ( 'yes' === $this->wcj_get_option( 'round', $current_gateway ) ) {
+							$final_fee_to_add = round( $final_fee_to_add, $this->wcj_get_option( 'round_precision', $current_gateway ) );
+						}
+						break;
+				}
+				if ( 0.0 !== (float) $final_fee_to_add ) {
+					$taxable        = ( 'yes' === $this->wcj_get_option( 'is_taxable', $current_gateway ) );
+					$tax_class_name = '';
+					if ( $taxable ) {
+						$tax_class_id    = $this->wcj_get_option( 'tax_class_id', $current_gateway );
+						$tax_class_names = array_merge( array( '' ), WC_Tax::get_tax_classes() );
+						$tax_class_name  = isset( $tax_class_names[ $tax_class_id ] ) ? $tax_class_names[ $tax_class_id ] : '';
 					}
+					$cart->add_fee( $fee_text, $final_fee_to_add, $taxable, $tax_class_name );
 				}
 			}
 		}

--- a/includes/class-wcj-pdf-invoicing.php
+++ b/includes/class-wcj-pdf-invoicing.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - PDF Invoicing
  *
- * @version 7.3.0
+ * @version 8.1.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
  */
@@ -53,6 +53,25 @@ if ( ! class_exists( 'WCJ_PDF_Invoicing' ) ) :
 		 * @var varchar $the_pdf_invoicing_report_tool Module.
 		 */
 		public $the_pdf_invoicing_report_tool;
+
+		/**
+		 * Enabled invoice types cached for the current request.
+		 *
+		 * @var array|null
+		 */
+		private $enabled_invoice_types = null;
+
+		/**
+		 * Get enabled invoice types once per request.
+		 *
+		 * @return array
+		 */
+		private function get_enabled_invoice_types() {
+			if ( null === $this->enabled_invoice_types ) {
+				$this->enabled_invoice_types = wcj_get_enabled_invoice_types();
+			}
+			return $this->enabled_invoice_types;
+		}
 		/**
 		 * Constructor.
 		 *
@@ -99,7 +118,7 @@ if ( ! class_exists( 'WCJ_PDF_Invoicing' ) ) :
 
 				$this->the_pdf_invoicing_report_tool = include_once 'pdf-invoices/class-wcj-pdf-invoicing-report-tool.php';
 
-				$invoice_types = wcj_get_enabled_invoice_types();
+				$invoice_types = $this->get_enabled_invoice_types();
 				foreach ( $invoice_types as $invoice_type ) {
 					$the_hooks = wcj_get_invoice_create_on( $invoice_type['id'] );
 					foreach ( $the_hooks as $the_hook ) {
@@ -137,7 +156,7 @@ if ( ! class_exists( 'WCJ_PDF_Invoicing' ) ) :
 		 * @return array
 		 */
 		public function bulk_actions_register( $actions ) {
-			$invoice_types      = wcj_get_enabled_invoice_types();
+			$invoice_types      = $this->get_enabled_invoice_types();
 			$new_actions_source = array(
 				'generate' => __( 'Generate', 'woocommerce-jetpack' ),
 				'download' => __( 'Download (Zip)', 'woocommerce-jetpack' ),
@@ -467,7 +486,7 @@ if ( ! class_exists( 'WCJ_PDF_Invoicing' ) ) :
 			) {
 				$current_filter = 'woocommerce_new_order';
 			}
-			$invoice_types = wcj_get_enabled_invoice_types();
+			$invoice_types = $this->get_enabled_invoice_types();
 			foreach ( $invoice_types as $invoice_type ) {
 				$the_hooks = wcj_get_invoice_create_on( $invoice_type['id'] );
 				foreach ( $the_hooks as $the_hook ) {
@@ -535,7 +554,7 @@ if ( ! class_exists( 'WCJ_PDF_Invoicing' ) ) :
 		/**
 		 * Gets an order customer ID through WooCommerce order APIs when available.
 		 *
-		 * @version 8.0.2
+		 * @version 8.1.0
 		 * @since   8.0.2
 		 * @param int $order_id defines the order ID.
 		 * @return int
@@ -547,7 +566,7 @@ if ( ! class_exists( 'WCJ_PDF_Invoicing' ) ) :
 				return (int) $order->get_customer_id();
 			}
 
-			return (int) get_post_meta( $order_id, '_customer_user', true );
+			return 0;
 		}
 
 		/**

--- a/includes/class-wcj-product-addons.php
+++ b/includes/class-wcj-product-addons.php
@@ -100,7 +100,7 @@ if ( ! class_exists( 'WCJ_Product_Addons' ) ) :
 					if ( WCJ_IS_WC_VERSION_BELOW_3 ) {
 						add_action( 'woocommerce_add_order_item_meta', array( $this, 'add_info_to_order_item_meta' ), PHP_INT_MAX, 3 );
 					} else {
-						add_action( 'woocommerce_new_order_item', array( $this, 'add_info_to_order_item_meta_wc3' ), PHP_INT_MAX, 3 );
+						add_action( 'woocommerce_checkout_create_order_line_item', array( $this, 'add_info_to_order_line_item' ), PHP_INT_MAX, 4 );
 					}
 				}
 				if ( is_admin() ) {
@@ -720,18 +720,37 @@ if ( ! class_exists( 'WCJ_Product_Addons' ) ) :
 		}
 
 		/**
-		 * Add_info_to_order_item_meta_wc3.
+		 * Add product addon data to a modern WooCommerce order line item.
 		 *
-		 * @version 3.4.0
-		 * @since   3.4.0
-		 * @todo    this is only a temporary solution: must replace `$item->legacy_values` (check "Bookings" module - `woocommerce_checkout_create_order_line_item` hook)
-		 * @param int   $item_id defines the item_id.
-		 * @param array $item defines the item.
-		 * @param int   $order_id defines the order_id.
+		 * Runs before WooCommerce saves the item, so it works for both Classic and
+		 * Store API checkout without using the removed legacy_values property or
+		 * triggering additional database writes.
+		 *
+		 * @version 8.1.0
+		 * @since   8.1.0
+		 * @param WC_Order_Item_Product $item          Order line item.
+		 * @param string                $cart_item_key Cart item key.
+		 * @param array                 $values        Cart item values.
+		 * @param WC_Order              $order         Order object.
 		 */
-		public function add_info_to_order_item_meta_wc3( $item_id, $item, $order_id ) {
-			if ( is_a( $item, 'WC_Order_Item_Product' ) ) {
-				$this->add_info_to_order_item_meta( $item_id, $item->legacy_values, null );
+		public function add_info_to_order_line_item( $item, $cart_item_key, $values, $order ) {
+			if ( ! $item instanceof WC_Order_Item_Product || empty( $values['product_id'] ) ) {
+				return;
+			}
+
+			$product = isset( $values['data'] ) && $values['data'] instanceof WC_Product
+				? $values['data']
+				: wc_get_product( ! empty( $values['variation_id'] ) ? $values['variation_id'] : $values['product_id'] );
+			if ( ! $product ) {
+				return;
+			}
+
+			foreach ( $this->get_product_addons( $values['product_id'] ) as $addon ) {
+				if ( ! isset( $values[ $addon['price_key'] ] ) ) {
+					continue;
+				}
+				$item->update_meta_data( '_' . $addon['price_key'], $this->maybe_convert_currency( $values[ $addon['price_key'] ], $product ) );
+				$item->update_meta_data( '_' . $addon['label_key'], $this->get_cart_addon_label( $values, $addon ) );
 			}
 		}
 

--- a/includes/classes/class-wcj-invoice.php
+++ b/includes/classes/class-wcj-invoice.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce Invoice
  *
- * @version 7.1.6
+ * @version 8.1.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/classes
  */
@@ -16,7 +16,7 @@ if ( ! class_exists( 'WCJ_Invoice' ) ) :
 		/**
 		 * WCJ_Invoice.
 		 *
-		 * @version 7.1.6
+		 * @version 8.1.0
 		 */
 	class WCJ_Invoice {
 		/**
@@ -39,47 +39,55 @@ if ( ! class_exists( 'WCJ_Invoice' ) ) :
 		public $wcj_invoice_type;
 
 		/**
+		 * Request-scoped order object.
+		 *
+		 * @var WC_Order|false|null
+		 */
+		private $order = null;
+
+		/**
 		 * Constructor.
 		 *
 		 * @param int    $order_id Get order id.
 		 * @param string $invoice_type  get invoice type.
 		 */
 		public function __construct( $order_id, $invoice_type ) {
-			$this->order_id     = $order_id;
+			$this->order_id     = absint( $order_id );
 			$this->invoice_type = $invoice_type;
+		}
+
+		/**
+		 * Get the invoice order once per request.
+		 *
+		 * @return WC_Order|false
+		 */
+		private function get_order() {
+			if ( null === $this->order ) {
+				$this->order = wc_get_order( $this->order_id );
+			}
+			return $this->order;
 		}
 
 		/**
 		 * Is_created.
 		 */
 		public function is_created() {
-			if ( true === wcj_is_hpos_enabled() ) {
-				$order = wcj_get_order( $this->order_id );
-				if ( $order && false !== $order ) {
-					return ( '' !== $order->get_meta( '_wcj_invoicing_' . $this->invoice_type . '_date' ) );
-				}
-			} else {
-				return ( '' !== get_post_meta( $this->order_id, '_wcj_invoicing_' . $this->invoice_type . '_date', true ) );
-			}
+			$order = $this->get_order();
+			return $order ? '' !== $order->get_meta( '_wcj_invoicing_' . $this->invoice_type . '_date' ) : false;
 		}
 
 		/**
 		 * Delete.
 		 *
-		 * @version 7.1.4
+		 * @version 8.1.0
 		 * @todo    removed update_option( $option_name, ( $the_invoice_counter - 1 ) ); It was causing the issue on the count.
 		 */
 		public function delete() {
-			if ( true === wcj_is_hpos_enabled() ) {
-				$order = wcj_get_order( $this->order_id );
-				if ( $order && false !== $order ) {
-					$order->update_meta_data( '_wcj_invoicing_' . $this->invoice_type . '_number_id', 0 );
-					$order->update_meta_data( '_wcj_invoicing_' . $this->invoice_type . '_date', '' );
-					$order->save();
-				}
-			} else {
-				update_post_meta( $this->order_id, '_wcj_invoicing_' . $this->invoice_type . '_number_id', 0 );
-				update_post_meta( $this->order_id, '_wcj_invoicing_' . $this->invoice_type . '_date', '' );
+			$order = $this->get_order();
+			if ( $order ) {
+				$order->update_meta_data( '_wcj_invoicing_' . $this->invoice_type . '_number_id', 0 );
+				$order->update_meta_data( '_wcj_invoicing_' . $this->invoice_type . '_date', '' );
+				$order->save();
 			}
 			if ( 'yes' === wcj_get_option( 'wcj_invoicing_' . $this->invoice_type . '_sequential_enabled', 'no' ) ) {
 				$option_name         = 'wcj_invoicing_' . $this->invoice_type . '_numbering_counter';
@@ -90,7 +98,7 @@ if ( ! class_exists( 'WCJ_Invoice' ) ) :
 		/**
 		 * Create.
 		 *
-		 * @version 7.1.4
+		 * @version 8.1.0
 		 * @todo    use mysql transaction enabled (as in "wcj_order_number_use_mysql_transaction_enabled")
 		 * @todo    used get_option instead wcj_get_option to get current numbering_counter.
 		 * @param number $date get date.
@@ -99,9 +107,12 @@ if ( ! class_exists( 'WCJ_Invoice' ) ) :
 
 			$order_id     = $this->order_id;
 			$invoice_type = $this->invoice_type;
+			$order = $this->get_order();
+			if ( ! $order ) {
+				return;
+			}
 			if ( 'yes' === wcj_get_option( 'wcj_invoicing_' . $invoice_type . '_skip_zero_total', 'no' ) ) {
-				$_order = wc_get_order( $order_id );
-				if ( 0 === (int) $_order->get_total() ) {
+				if ( 0 === (int) $order->get_total() ) {
 					return;
 				}
 			}
@@ -112,17 +123,9 @@ if ( ! class_exists( 'WCJ_Invoice' ) ) :
 				$the_invoice_number = $order_id;
 			}
 			$the_date = ( '' === $date ) ? (string) wcj_get_timestamp_date_from_gmt() : $date;
-			if ( true === wcj_is_hpos_enabled() ) {
-				$order = wcj_get_order( $order_id );
-				if ( $order && false !== $order ) {
-					$order->update_meta_data( '_wcj_invoicing_' . $invoice_type . '_number_id', $the_invoice_number );
-					$order->update_meta_data( '_wcj_invoicing_' . $invoice_type . '_date', $the_date );
-					$order->save();
-				}
-			} else {
-				update_post_meta( $order_id, '_wcj_invoicing_' . $invoice_type . '_number_id', $the_invoice_number );
-				update_post_meta( $order_id, '_wcj_invoicing_' . $invoice_type . '_date', $the_date );
-			}
+			$order->update_meta_data( '_wcj_invoicing_' . $invoice_type . '_number_id', $the_invoice_number );
+			$order->update_meta_data( '_wcj_invoicing_' . $invoice_type . '_date', $the_date );
+			$order->save();
 		}
 
 		/**
@@ -142,45 +145,27 @@ if ( ! class_exists( 'WCJ_Invoice' ) ) :
 		 * Get_invoice_date.
 		 */
 		public function get_invoice_date() {
-			if ( true === wcj_is_hpos_enabled() ) {
-				$order = wcj_get_order( $this->order_id );
-				if ( $order && false !== $order ) {
-					$the_date = $order->get_meta( '_wcj_invoicing_' . $this->invoice_type . '_date' );
-				}
-			} else {
-				$the_date = get_post_meta( $this->order_id, '_wcj_invoicing_' . $this->invoice_type . '_date', true );
-			}
+			$order    = $this->get_order();
+			$the_date = $order ? $order->get_meta( '_wcj_invoicing_' . $this->invoice_type . '_date' ) : '';
 			return apply_filters( 'wcj_get_' . $this->invoice_type . '_date', $the_date, $this->order_id );
 		}
 
 		/**
 		 * Get_invoice_number.
 		 *
-		 * @version 7.1.4
+		 * @version 8.1.0
 		 */
 		public function get_invoice_number() {
-			if ( true === wcj_is_hpos_enabled() ) {
-				$order = wcj_get_order( $this->order_id );
-				if ( $order && false !== $order ) {
-					$replaced_values = array(
-						'%prefix%'  => wcj_get_option( 'wcj_invoicing_' . $this->invoice_type . '_numbering_prefix', '' ),
-						'%counter%' => sprintf(
-							'%0' . wcj_get_option( 'wcj_invoicing_' . $this->invoice_type . '_numbering_counter_width', 0 ) . 'd',
-							$order->get_meta( '_wcj_invoicing_' . $this->invoice_type . '_number_id' )
-						),
-						'%suffix%'  => wcj_get_option( 'wcj_invoicing_' . $this->invoice_type . '_numbering_suffix', '' ),
-					);
-				}
-			} else {
-				$replaced_values = array(
-					'%prefix%'  => wcj_get_option( 'wcj_invoicing_' . $this->invoice_type . '_numbering_prefix', '' ),
-					'%counter%' => sprintf(
-						'%0' . wcj_get_option( 'wcj_invoicing_' . $this->invoice_type . '_numbering_counter_width', 0 ) . 'd',
-						get_post_meta( $this->order_id, '_wcj_invoicing_' . $this->invoice_type . '_number_id', true )
-					),
-					'%suffix%'  => wcj_get_option( 'wcj_invoicing_' . $this->invoice_type . '_numbering_suffix', '' ),
-				);
-			}
+			$order             = $this->get_order();
+			$invoice_number_id = $order ? $order->get_meta( '_wcj_invoicing_' . $this->invoice_type . '_number_id' ) : 0;
+			$replaced_values   = array(
+				'%prefix%'  => wcj_get_option( 'wcj_invoicing_' . $this->invoice_type . '_numbering_prefix', '' ),
+				'%counter%' => sprintf(
+					'%0' . wcj_get_option( 'wcj_invoicing_' . $this->invoice_type . '_numbering_counter_width', 0 ) . 'd',
+					$invoice_number_id
+				),
+				'%suffix%'  => wcj_get_option( 'wcj_invoicing_' . $this->invoice_type . '_numbering_suffix', '' ),
+			);
 			return apply_filters(
 				'wcj_get_' . $this->invoice_type . '_number',
 				do_shortcode(

--- a/includes/input-fields/class-wcj-product-input-fields-core.php
+++ b/includes/input-fields/class-wcj-product-input-fields-core.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Product Input Fields - Core
  *
- * @version 7.2.5
+ * @version 8.1.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
  */
@@ -15,7 +15,7 @@ if ( ! class_exists( 'WCJ_Product_Input_Fields_Core' ) ) :
 	/**
 	 * WCJ_Product_Input_Fields_Core
 	 *
-	 * @version 7.1.6
+	 * @version 8.1.0
 	 * @since   4.2.0
 	 */
 	class WCJ_Product_Input_Fields_Core {
@@ -34,6 +34,20 @@ if ( ! class_exists( 'WCJ_Product_Input_Fields_Core' ) ) :
 		 * @var varchar $are_product_input_fields_displayed Module are_product_input_fields_displayed.
 		 */
 		public $are_product_input_fields_displayed;
+
+		/**
+		 * Request-scoped option values keyed by product and option name.
+		 *
+		 * @var array
+		 */
+		private $value_cache = array();
+
+		/**
+		 * Request-scoped local configuration arrays keyed by product ID.
+		 *
+		 * @var array
+		 */
+		private $local_options_cache = array();
 
 		/**
 		 * Constructor.
@@ -205,14 +219,14 @@ if ( ! class_exists( 'WCJ_Product_Input_Fields_Core' ) ) :
 		/**
 		 * Save product input fields on Product Edit.
 		 *
-		 * @version 5.6.3
+	 * @version 8.1.0
 		 * @param int         $post_id Get post ID.
 		 * @param obj | Array $post Get post.
 		 */
 		public function save_local_product_input_fields_on_product_edit( $post_id, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 			$wpnonce = wp_verify_nonce( wp_unslash( isset( $_POST['woocommerce_meta_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['woocommerce_meta_nonce'] ) ) : '' ), 'woocommerce_save_data' );
 			// Check that we are saving with input fields displayed.
-			if ( ! $wpnonce || ! isset( $_POST['woojetpack_product_input_fields_save_post'] ) ) {
+			if ( ! $wpnonce || ! current_user_can( 'edit_post', $post_id ) || ! isset( $_POST['woojetpack_product_input_fields_save_post'] ) ) {
 				return;
 			}
 			// Save values.
@@ -234,6 +248,8 @@ if ( ! class_exists( 'WCJ_Product_Input_Fields_Core' ) ) :
 				}
 			}
 			update_post_meta( $post_id, '_wcj_product_input_fields', $values );
+			unset( $this->local_options_cache[ (int) $post_id ] );
+			$this->value_cache = array();
 		}
 
 		/**
@@ -521,24 +537,37 @@ if ( ! class_exists( 'WCJ_Product_Input_Fields_Core' ) ) :
 		/**
 		 * Get_value.
 		 *
-		 * @version 5.6.2
+	 * @version 8.1.0
 		 * @todo    `wcj_get_product_input_field_value()` is almost identical
 		 * @param string $option_name Get option name.
 		 * @param int    $product_id Get product id.
 		 * @param string $default Get default value.
 		 */
 		public function get_value( $option_name, $product_id, $default ) {
+			$cache_key = (int) $product_id . '|' . $option_name . '|' . md5( maybe_serialize( $default ) );
+			if ( array_key_exists( $cache_key, $this->value_cache ) ) {
+				return $this->value_cache[ $cache_key ];
+			}
+
 			if ( 'global' === $this->scope ) {
-				return wcj_get_option( $option_name, $default );
+				$value = wcj_get_option( $option_name, $default );
 			} else { // local.
-				$options = get_post_meta( $product_id, '_wcj_product_input_fields', true );
+				$product_id = (int) $product_id;
+				if ( ! array_key_exists( $product_id, $this->local_options_cache ) ) {
+					$this->local_options_cache[ $product_id ] = get_post_meta( $product_id, '_wcj_product_input_fields', true );
+				}
+				$options = $this->local_options_cache[ $product_id ];
 				if ( '' !== ( $options ) ) {
-					$option_name = str_replace( 'wcj_product_input_fields_', '', $option_name );
-					return ( isset( $options[ $option_name ] ) ? $options[ $option_name ] : $default );
+					$local_key = str_replace( 'wcj_product_input_fields_', '', $option_name );
+					$value     = is_array( $options ) && isset( $options[ $local_key ] ) ? $options[ $local_key ] : $default;
 				} else { // Booster version  < 3.5.0.
-					return get_post_meta( $product_id, '_' . $option_name, true );
+					$legacy_value = get_post_meta( $product_id, '_' . $option_name, true );
+					$value        = '' !== $legacy_value ? $legacy_value : $default;
 				}
 			}
+
+			$this->value_cache[ $cache_key ] = $value;
+			return $value;
 		}
 
 		/**
@@ -889,13 +918,14 @@ if ( ! class_exists( 'WCJ_Product_Input_Fields_Core' ) ) :
 		 *
 		 * From `$_POST` to `$cart_item_data`
 		 *
-		 * @version 5.6.8
+	 * @version 8.1.0
 		 * @param Array $cart_item_data Get cart items.
 		 * @param int   $product_id Get product id.
 		 * @param int   $variation_id Get variation id.
 		 */
 		public function add_product_input_fields_to_cart_item_data( $cart_item_data, $product_id, $variation_id ) {
-			$wpnonce = isset( $_REQUEST['wcj_product_input_fields-nonce'] ) ? wp_verify_nonce( sanitize_key( $_REQUEST['wcj_product_input_fields-nonce'] ), 'wcj_product_input_fields' ) : false;
+			$nonce   = isset( $_REQUEST['wcj_product_input_fields-nonce'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['wcj_product_input_fields-nonce'] ) ) : '';
+			$wpnonce = wp_verify_nonce( $nonce, 'wcj_product_input_fields' );
 			if ( ! $wpnonce ) {
 				return $cart_item_data;
 			}

--- a/includes/pdf-invoices/class-wcj-pdf-invoicing-report-tool.php
+++ b/includes/pdf-invoices/class-wcj-pdf-invoicing-report-tool.php
@@ -325,7 +325,7 @@ if ( ! class_exists( 'WCJ_PDF_Invoicing_Report_Tool' ) ) :
 				$args   = array(
 					'type'           => 'shop_order',
 					'status'         => 'any',
-					'posts_per_page' => $block_size,
+					'limit'          => $block_size,
 					'orderby'        => 'meta_value_num',
 					'meta_key'       => '_wcj_invoicing_' . $invoice_type_id . '_date', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 					'order'          => 'ASC',
@@ -338,7 +338,7 @@ if ( ! class_exists( 'WCJ_PDF_Invoicing_Report_Tool' ) ) :
 						),
 					),
 					'offset'         => $offset,
-					'fields'         => 'ids',
+					'return'         => 'objects',
 				);
 				$orders = wc_get_orders( $args );
 				if ( ! $orders ) {
@@ -502,175 +502,8 @@ if ( ! class_exists( 'WCJ_PDF_Invoicing_Report_Tool' ) ) :
 					if ( wcj_is_invoice_created( $order_id, $invoice_type_id ) ) {
 
 						$the_order = wc_get_order( $order_id );
-
-						$user_meta        = get_user_meta( $the_order->get_user_id() );
-						$billing_country  = isset( $user_meta['billing_country'][0] ) ? $user_meta['billing_country'][0] : '';
-						$shipping_country = isset( $user_meta['shipping_country'][0] ) ? $user_meta['shipping_country'][0] : '';
-						$customer_country = ( '' === $billing_country ) ? $shipping_country : $billing_country;
-						$customer_vat_id  = get_post_meta( $order_id, '_billing_eu_vat_number', true );
-
-						$order_total = $the_order->get_total();
-
-						$order_tax                   = apply_filters( 'wcj_order_total_tax', $the_order->get_total_tax(), $the_order );
-						$order_total_exlc_tax        = $order_total - $order_tax;
-						$order_total_tax_not_rounded = $the_order->get_cart_tax() + $the_order->get_shipping_tax();
-						$order_total_exlc_tax        = (float) 0 === $order_total_exlc_tax ? 0 : $order_total_exlc_tax;
-						$order_tax_percent           = ( 0 === $order_total_exlc_tax ? 0 : $order_total_tax_not_rounded / $order_total_exlc_tax );
-
-						$total_sum          += $order_total;
-						$total_sum_excl_tax += $order_total_exlc_tax;
-						$total_tax          += $order_tax;
-
-						$order_cart_tax            = $the_order->get_cart_tax();
-						$order_shipping_tax        = $the_order->get_shipping_tax();
-						$order_cart_total_excl_tax = 0;
-						foreach ( $the_order->get_items() as $item ) {
-							$order_cart_total_excl_tax += $item->get_total();
-						}
-						$order_shipping_total_excl_tax = $the_order->get_shipping_total();
-
-						if ( 0 === $order_cart_total_excl_tax || '0' === $order_cart_tax ) {
-							$order_cart_tax_percent = 0;
-						} else {
-							$order_cart_tax_percent = ( 0 === $order_cart_total_excl_tax ? 0 : $order_cart_tax / $order_cart_total_excl_tax );
-						}
-
-						if ( 0 === $order_shipping_total_excl_tax || '0' === $order_shipping_tax ) {
-							$order_shipping_tax_percent = 0;
-						} else {
-							$order_shipping_tax_percent = ( 0 === $order_shipping_total_excl_tax ? 0 : $order_shipping_tax / $order_shipping_total_excl_tax );
-						}
-
-						$row = array();
-						foreach ( $columns as $column ) {
-							switch ( $column ) {
-								case 'document_number':
-									$row[] = wcj_get_invoice_number( $order_id, $invoice_type_id );
-									break;
-								case 'document_date':
-									$row[] = wcj_get_invoice_date( $order_id, $invoice_type_id, 0, wcj_get_option( 'date_format' ) );
-									break;
-								case 'order_id':
-									$row[] = $order_id;
-									break;
-								case 'customer_country':
-									$row[] = $customer_country;
-									break;
-								case 'customer_vat_id':
-									$row[] = $customer_vat_id;
-									break;
-								case 'tax_percent':
-									$row[] = sprintf( $tax_percent_format, $order_tax_percent * 100 );
-									break;
-								case 'order_total_tax_excluding':
-									$row[] = sprintf( '%.2f', $order_total_exlc_tax );
-									break;
-								case 'order_taxes':
-									$row[] = sprintf( '%.2f', $order_tax );
-									break;
-								case 'order_cart_total_excl_tax':
-									$row[] = sprintf( '%.2f', $order_cart_total_excl_tax );
-									break;
-								case 'order_cart_tax':
-									$row[] = sprintf( '%.2f', $order_cart_tax );
-									break;
-								case 'order_cart_tax_percent':
-									$row[] = sprintf( $tax_percent_format, $order_cart_tax_percent * 100 );
-									break;
-								case 'order_shipping_total_excl_tax':
-									$row[] = sprintf( '%.2f', $order_shipping_total_excl_tax );
-									break;
-								case 'order_shipping_tax':
-									$row[] = sprintf( '%.2f', $order_shipping_tax );
-									break;
-								case 'order_shipping_tax_percent':
-									$row[] = sprintf( $tax_percent_format, $order_shipping_tax_percent * 100 );
-									break;
-								case 'order_total':
-									$row[] = sprintf( '%.2f', $order_total );
-									break;
-								case 'order_currency':
-									$row[] = wcj_get_order_currency( $the_order );
-									break;
-								case 'payment_gateway':
-									$row[] = get_post_meta( $order_id, '_payment_method_title', true );
-									break;
-								case 'refunds':
-									$row[] = $the_order->get_total_refunded();
-									break;
-							}
-						}
-						$data[] = apply_filters( 'wcj_pdf_invoicing_report_tool_row', $row );
-					}
-				}
-				$offset += $block_size;
-			}
-
-			$headers = $this->get_data_headers( $columns );
-
-			return ( ! empty( $data ) ? array_merge( array( $headers ), $data ) : array() );
-		}
-
-		/**
-		 * Invoices Report Data function HPOS.
-		 *
-		 * @version 7.1.4
-		 * @since   1.0.0
-		 * @param int | string $year Get year.
-		 * @param int | string $month Get month.
-		 * @param int          $invoice_type_id Get invoice type id.
-		 */
-		public function get_invoices_report_data_hpos( $year, $month, $invoice_type_id ) {
-
-			$columns = wcj_get_option( 'wcj_pdf_invoicing_report_tool_columns', '' );
-			if ( empty( $columns ) ) {
-				$columns = array_keys( w_c_j()->all_modules['pdf_invoicing_advanced']->get_report_columns() );
-			}
-
-			$total_sum          = 0;
-			$total_sum_excl_tax = 0;
-			$total_tax          = 0;
-
-			$first_minute = mktime( 0, 0, 0, $month, 1, $year );
-			$last_minute  = mktime( 23, 59, 59, $month, gmdate( 't', $first_minute ), $year );
-
-			$tax_percent_format = '%.' . wcj_get_option( 'wcj_pdf_invoicing_report_tool_tax_percent_precision', 0 ) . 'f %%';
-
-			$data       = array();
-			$offset     = 0;
-			$block_size = 512;
-			while ( true ) {
-				$args   = array(
-					'type'           => 'shop_order',
-					'status'         => 'any',
-					'posts_per_page' => $block_size,
-					'orderby'        => 'meta_value_num',
-					'meta_key'       => '_wcj_invoicing_' . $invoice_type_id . '_date', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-					'order'          => 'ASC',
-					'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-						array(
-							'key'     => '_wcj_invoicing_' . $invoice_type_id . '_date',
-							'value'   => array( $first_minute, $last_minute ),
-							'type'    => 'numeric',
-							'compare' => 'BETWEEN',
-						),
-					),
-					'offset'         => $offset,
-					'fields'         => 'ids',
-				);
-				$orders = wc_get_orders( $args );
-				if ( ! $orders ) {
-					break;
-				}
-				foreach ( $orders as $order ) {
-						$order_id = $order->get_id();
-					if ( wcj_is_invoice_created( $order_id, $invoice_type_id ) ) {
-
-						$the_order = wc_get_order( $order_id );
-
-						$user_meta        = get_user_meta( $the_order->get_user_id() );
-						$billing_country  = isset( $user_meta['billing_country'][0] ) ? $user_meta['billing_country'][0] : '';
-						$shipping_country = isset( $user_meta['shipping_country'][0] ) ? $user_meta['shipping_country'][0] : '';
+						$billing_country  = $the_order->get_billing_country();
+						$shipping_country = $the_order->get_shipping_country();
 						$customer_country = ( '' === $billing_country ) ? $shipping_country : $billing_country;
 						$customer_vat_id  = $the_order->get_meta( '_billing_eu_vat_number' );
 
@@ -758,7 +591,171 @@ if ( ! class_exists( 'WCJ_PDF_Invoicing_Report_Tool' ) ) :
 									$row[] = wcj_get_order_currency( $the_order );
 									break;
 								case 'payment_gateway':
-									$row[] = $the_order->get_meta( '_payment_method_title' );
+									$row[] = $the_order->get_payment_method_title();
+									break;
+								case 'refunds':
+									$row[] = $the_order->get_total_refunded();
+									break;
+							}
+						}
+						$data[] = apply_filters( 'wcj_pdf_invoicing_report_tool_row', $row );
+					}
+				}
+				$offset += $block_size;
+			}
+
+			$headers = $this->get_data_headers( $columns );
+
+			return ( ! empty( $data ) ? array_merge( array( $headers ), $data ) : array() );
+		}
+
+		/**
+		 * Invoices Report Data function HPOS.
+		 *
+		 * @version 7.1.4
+		 * @since   1.0.0
+		 * @param int | string $year Get year.
+		 * @param int | string $month Get month.
+		 * @param int          $invoice_type_id Get invoice type id.
+		 */
+		public function get_invoices_report_data_hpos( $year, $month, $invoice_type_id ) {
+
+			$columns = wcj_get_option( 'wcj_pdf_invoicing_report_tool_columns', '' );
+			if ( empty( $columns ) ) {
+				$columns = array_keys( w_c_j()->all_modules['pdf_invoicing_advanced']->get_report_columns() );
+			}
+
+			$total_sum          = 0;
+			$total_sum_excl_tax = 0;
+			$total_tax          = 0;
+
+			$first_minute = mktime( 0, 0, 0, $month, 1, $year );
+			$last_minute  = mktime( 23, 59, 59, $month, gmdate( 't', $first_minute ), $year );
+
+			$tax_percent_format = '%.' . wcj_get_option( 'wcj_pdf_invoicing_report_tool_tax_percent_precision', 0 ) . 'f %%';
+
+			$data       = array();
+			$offset     = 0;
+			$block_size = 512;
+			while ( true ) {
+				$args   = array(
+					'type'           => 'shop_order',
+					'status'         => 'any',
+					'limit'          => $block_size,
+					'orderby'        => 'meta_value_num',
+					'meta_key'       => '_wcj_invoicing_' . $invoice_type_id . '_date', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+					'order'          => 'ASC',
+					'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+						array(
+							'key'     => '_wcj_invoicing_' . $invoice_type_id . '_date',
+							'value'   => array( $first_minute, $last_minute ),
+							'type'    => 'numeric',
+							'compare' => 'BETWEEN',
+						),
+					),
+					'offset'         => $offset,
+					'return'         => 'objects',
+				);
+				$orders = wc_get_orders( $args );
+				if ( ! $orders ) {
+					break;
+				}
+				foreach ( $orders as $order ) {
+					$order_id = $order->get_id();
+					if ( wcj_is_invoice_created( $order_id, $invoice_type_id ) ) {
+
+						$the_order = $order;
+
+						$billing_country  = $the_order->get_billing_country();
+						$shipping_country = $the_order->get_shipping_country();
+						$customer_country = ( '' === $billing_country ) ? $shipping_country : $billing_country;
+						$customer_vat_id  = $the_order->get_meta( '_billing_eu_vat_number' );
+
+						$order_total = $the_order->get_total();
+
+						$order_tax                   = apply_filters( 'wcj_order_total_tax', $the_order->get_total_tax(), $the_order );
+						$order_total_exlc_tax        = $order_total - $order_tax;
+						$order_total_tax_not_rounded = $the_order->get_cart_tax() + $the_order->get_shipping_tax();
+						$order_total_exlc_tax        = (float) 0 === $order_total_exlc_tax ? 0 : $order_total_exlc_tax;
+						$order_tax_percent           = ( 0 === $order_total_exlc_tax ? 0 : $order_total_tax_not_rounded / $order_total_exlc_tax );
+
+						$total_sum          += $order_total;
+						$total_sum_excl_tax += $order_total_exlc_tax;
+						$total_tax          += $order_tax;
+
+						$order_cart_tax            = $the_order->get_cart_tax();
+						$order_shipping_tax        = $the_order->get_shipping_tax();
+						$order_cart_total_excl_tax = 0;
+						foreach ( $the_order->get_items() as $item ) {
+							$order_cart_total_excl_tax += $item->get_total();
+						}
+						$order_shipping_total_excl_tax = $the_order->get_shipping_total();
+
+						if ( 0 === $order_cart_total_excl_tax || '0' === $order_cart_tax ) {
+							$order_cart_tax_percent = 0;
+						} else {
+							$order_cart_tax_percent = ( 0 === $order_cart_total_excl_tax ? 0 : $order_cart_tax / $order_cart_total_excl_tax );
+						}
+
+						if ( 0 === $order_shipping_total_excl_tax || '0' === $order_shipping_tax ) {
+							$order_shipping_tax_percent = 0;
+						} else {
+							$order_shipping_tax_percent = ( 0 === $order_shipping_total_excl_tax ? 0 : $order_shipping_tax / $order_shipping_total_excl_tax );
+						}
+
+						$row = array();
+						foreach ( $columns as $column ) {
+							switch ( $column ) {
+								case 'document_number':
+									$row[] = wcj_get_invoice_number( $order_id, $invoice_type_id );
+									break;
+								case 'document_date':
+									$row[] = wcj_get_invoice_date( $order_id, $invoice_type_id, 0, wcj_get_option( 'date_format' ) );
+									break;
+								case 'order_id':
+									$row[] = $order_id;
+									break;
+								case 'customer_country':
+									$row[] = $customer_country;
+									break;
+								case 'customer_vat_id':
+									$row[] = $customer_vat_id;
+									break;
+								case 'tax_percent':
+									$row[] = sprintf( $tax_percent_format, $order_tax_percent * 100 );
+									break;
+								case 'order_total_tax_excluding':
+									$row[] = sprintf( '%.2f', $order_total_exlc_tax );
+									break;
+								case 'order_taxes':
+									$row[] = sprintf( '%.2f', $order_tax );
+									break;
+								case 'order_cart_total_excl_tax':
+									$row[] = sprintf( '%.2f', $order_cart_total_excl_tax );
+									break;
+								case 'order_cart_tax':
+									$row[] = sprintf( '%.2f', $order_cart_tax );
+									break;
+								case 'order_cart_tax_percent':
+									$row[] = sprintf( $tax_percent_format, $order_cart_tax_percent * 100 );
+									break;
+								case 'order_shipping_total_excl_tax':
+									$row[] = sprintf( '%.2f', $order_shipping_total_excl_tax );
+									break;
+								case 'order_shipping_tax':
+									$row[] = sprintf( '%.2f', $order_shipping_tax );
+									break;
+								case 'order_shipping_tax_percent':
+									$row[] = sprintf( $tax_percent_format, $order_shipping_tax_percent * 100 );
+									break;
+								case 'order_total':
+									$row[] = sprintf( '%.2f', $order_total );
+									break;
+								case 'order_currency':
+									$row[] = wcj_get_order_currency( $the_order );
+									break;
+								case 'payment_gateway':
+									$row[] = $the_order->get_payment_method_title();
 									break;
 								case 'refunds':
 									$row[] = $the_order->get_total_refunded();

--- a/includes/pdf-invoices/submodules/class-wcj-pdf-invoicing-display.php
+++ b/includes/pdf-invoices/submodules/class-wcj-pdf-invoicing-display.php
@@ -22,7 +22,7 @@ if ( ! class_exists( 'WCJ_PDF_Invoicing_Display' ) ) :
 		/**
 		 * Constructor.
 		 *
-		 * @version 7.1.4
+		 * @version 8.1.0
 		 */
 		public function __construct() {
 
@@ -442,21 +442,12 @@ if ( ! class_exists( 'WCJ_PDF_Invoicing_Display' ) ) :
 						if ( 'yes' === wcj_get_option( 'wcj_invoicing_add_order_meta_box_numbering', 'yes' ) ) {
 							$number_option = 'wcj_invoicing_' . $invoice_type['id'] . '_number_id';
 							$date_option   = 'wcj_invoicing_' . $invoice_type['id'] . '_date';
-							if ( true === wcj_is_hpos_enabled() ) {
-								$number_input = '<br>' .
-								'<input style="width:100%;" type="number"' .
-									' id="' . $number_option . '" name="' . $number_option . '" value="' . $_order->get_meta( '_' . $number_option ) . '">' .
-								'<input style="width:100%;" type="text"' .
-									' id="' . $date_option . '" name="' . $date_option . '" value="' . gmdate( 'Y-m-d H:i:s', $_order->get_meta( '_' . $date_option ) ) . '">' .
-								'<input type="hidden" name="woojetpack_pdf_invoicing_save_post" value="woojetpack_pdf_invoicing_save_post">';
-							} else {
-								$number_input = '<br>' .
-								'<input style="width:100%;" type="number"' .
-									' id="' . $number_option . '" name="' . $number_option . '" value="' . get_post_meta( $order_id, '_' . $number_option, true ) . '">' .
-								'<input style="width:100%;" type="text"' .
-									' id="' . $date_option . '" name="' . $date_option . '" value="' . gmdate( 'Y-m-d H:i:s', get_post_meta( $order_id, '_' . $date_option, true ) ) . '">' .
-								'<input type="hidden" name="woojetpack_pdf_invoicing_save_post" value="woojetpack_pdf_invoicing_save_post">';
-							}
+							$number_input = '<br>' .
+							'<input style="width:100%;" type="number"' .
+								' id="' . $number_option . '" name="' . $number_option . '" value="' . esc_attr( $_order->get_meta( '_' . $number_option ) ) . '">' .
+							'<input style="width:100%;" type="text"' .
+								' id="' . $date_option . '" name="' . $date_option . '" value="' . esc_attr( gmdate( 'Y-m-d H:i:s', (int) $_order->get_meta( '_' . $date_option ) ) ) . '">' .
+							'<input type="hidden" name="woojetpack_pdf_invoicing_save_post" value="woojetpack_pdf_invoicing_save_post">';
 						}
 						// Actions.
 						$actions = array( $view_link . ' | ' . $delete_link . $number_input );

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: woocommerce, abandoned cart, cart recovery, swatches, woocommerce pdf invo
 Requires at least: 5.8
 Tested up to: 7.0
 Requires PHP: 7.2
-Stable tag: 8.0.2
+Stable tag: 8.1.0
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -172,7 +172,7 @@ Yes, definitely! Because Booster is modular, you can activate only the specific 
 In many cases, yes! Booster's free core modules for features like <strong>PDF Invoicing</strong>, <strong>Currency Switching</strong>, and <strong>Checkout Field Editing</strong> are very robust and often provide comparable or even more functionality than many standalone free plugins. For advanced needs, <strong>Booster Elite</strong> frequently offers more comprehensive features than specialized premium plugins, all at a fraction of the total cost. We recommend trying the free module first and checking our feature comparison for Elite capabilities.
 
 = Is Booster compatible with the latest WooCommerce, WordPress, and features like HPOS? =
-Yes, Booster is <strong>regularly updated and fully compatible</strong> with the latest WordPress and WooCommerce versions. This includes seamless integration with modern WooCommerce architecture like <strong>High-Performance Order Storage (HPOS)</strong> for improved scalability, as well as <strong>WooCommerce Blocks</strong>, ensuring our toolkit stays current and performs optimally with all platform advancements.
+Booster is regularly updated and tested with current WordPress and WooCommerce releases. <strong>HPOS and Checkout Blocks compatibility is module-specific</strong>: supported workflows use modern WooCommerce APIs, while Booster's Compatibility Status guidance and release notes identify partial or Classic Checkout-only features.
 
 = Why should I choose Booster Elite over other individual premium plugins? =
 Implementing just a few premium modules from the Booster Elite suite is typically more **cost-effective** than buying multiple individual plugins (often priced at $49-$99 each). Stacking your WooCommerce site with many different plugins can also lead to slower performance and compatibility conflicts. **Booster Elite** solves these problems with over 110 compatible modules in a single, optimized package, simplifying your plugin management and saving you money.
@@ -346,6 +346,17 @@ No. Onboarding analytics are local-only (apply/undo/mode views) to improve the e
 * For support please visit the [Plugin Support Forum](https://wordpress.org/support/plugin/woocommerce-jetpack/).
 
 == Changelog ==
+
+= 8.1.0 - 15/07/2026 =
+* Checkout Blocks compatibility - Added supported Checkout Custom Fields to Blocks checkout with server-side validation, order saving, and module-specific product, category, and cart visibility on supported WooCommerce versions.
+* Checkout Blocks compatibility - Kept textarea fields, checkout-field-conditional fees, and checkout file collection on their safe Classic Checkout or post-order paths instead of overstating Blocks support.
+* HPOS compatibility - Modernized Order Numbers, Checkout Files Upload, PDF Invoicing, Checkout Custom Fields, Product Addons, and Product Input Fields to use WooCommerce order and order-item APIs in active order workflows.
+* Performance - Reused normalized fee, gateway, input-field, invoice, product, and category configuration within each request to reduce repeated work in cart, checkout, order, and PDF paths.
+* Reliability - Preserved conditional fees when a guest creates an account during Classic Checkout, prevented duplicate order-item writes, and strengthened fallbacks around checkout and order data.
+* Admin experience - Expanded module-level Checkout Blocks and HPOS status guidance with clear supported, partial, and Classic-only boundaries.
+* Tier-specific value - Improved the existing Free field, fee, upload, order-number, invoice, add-on, and input-field capabilities without enabling paid counts or premium controls.
+* Security hardening - Strengthened validation and request handling in selected customer-facing workflows.
+
 
 = 8.0.2 - 17/06/2026 =
 * Security - Hardened Product by User media upload handling and Free tier upload boundaries.

--- a/woocommerce-jetpack.php
+++ b/woocommerce-jetpack.php
@@ -4,7 +4,7 @@
  * Requires Plugins: woocommerce
  * Plugin URI: https://booster.io
  * Description: Supercharge your WooCommerce site with these awesome powerful features.
- * Version: 8.0.2
+ * Version: 8.1.0
  * Author: Pluggabl LLC
  * Author URI: https://booster.io
  * Text Domain: woocommerce-jetpack
@@ -72,7 +72,7 @@ if ( ! class_exists( 'WC_Jetpack' ) ) :
 		 *
 		 * @var string
 		 */
-		public $version = '8.0.2';
+		public $version = '8.1.0';
 
 		/**
 		 * Singleton instance.


### PR DESCRIPTION
﻿## Customer value

Booster 8.1.0 turns the June compatibility guidance into working, module-specific Checkout Blocks support, modernizes active order workflows for HPOS, reduces repeated work in checkout and document hot paths, and improves failure handling without changing Free feature limits.

Target release: **July 15, 2026**.

## Changes by module

- **Checkout Custom Fields**: Registers the supported Free field in Checkout Blocks through WooCommerce's Additional Checkout Fields API, validates and sanitizes server-side, saves through the order object, and preserves admin, account, thank-you, and email display. Product/category/cart rules are sent to the Store API on WooCommerce 9.9+.
- **Checkout Fees**: Detects Store API recalculation, reuses normalized fee rules during the request, corrects the checkout-field option lookup, and preserves the final Classic Checkout conditional fee calculation when a guest creates an account.
- **Payment Gateway Fees and Discounts**: Reuses chosen-gateway and cart-product state, avoids repeated cart scans, and handles Store API/session checkout paths more safely.
- **Checkout Files Upload**: Uses order CRUD with batched saves in HPOS and legacy storage, strengthens order/file authorization and managed-directory checks, and escapes customer/admin file output.
- **Product Addons**: Persists add-on order data through the modern line-item creation hook and avoids duplicate item saves.
- **Product Input Fields**: Adds request-scoped local configuration caching and safer save/request handling while preserving the single Free field limit.
- **Order Numbers**: Uses WooCommerce order APIs for creation, display, renumeration, and maintained tracking lookup paths.
- **PDF Invoicing**: Reuses enabled document configuration and order objects; report/admin data now reads historical order fields through WooCommerce APIs.
- **Compatibility Status**: Adds actionable module rows for supported, partial, and Classic-only Checkout Blocks behavior plus HPOS guidance.

## Checkout Blocks compatibility scope

Supported and validated:

- Checkout Custom Fields: text, select, checkbox, and radio rendered as a select.
- Server-side validation, sanitization, order saving, admin/account/thank-you/email display.
- Logged-in and guest Blocks checkout.
- Product, category, and cart-amount visibility rules on WooCommerce 9.9+.
- Simple Checkout Fees and Store API-aware gateway fee recalculation.

Intentional limits:

- Textarea and other unsupported Checkout Custom Field types remain Classic Checkout-only.
- Checkout-field-conditional fees remain Classic Checkout-only.
- Checkout Files Upload collection remains Classic Checkout-only; post-order/account paths remain available.
- This PR does not claim plugin-wide Checkout Blocks compatibility.

## HPOS scope

Modernized active paths in Checkout Custom Fields, Checkout Files Upload, Order Numbers, PDF Invoicing, invoice reports/admin display, Product Addons line items, and customer account/email integrations. Each targeted matrix was run with HPOS both disabled and enabled. Legacy fallbacks remain only for supported older/classic storage paths.

## Performance evidence

Identical Docker scenario, seven runs per source state, comparing released 8.0.2 with this branch:

| Scenario | 8.0.2 | 8.1.0 branch |
| --- | ---: | ---: |
| Product Input local config, 1,000 reads | 1,000 metadata API calls; 3.377 ms median | 1 metadata API call; 0.246 ms median |
| PDF enabled-type work, 250 calls | 1,004 Booster filter calls; 4.542 ms median | 4 Booster filter calls; 0.591 ms median |
| Database queries | 0-1 / 0 | 0 / 0 |

These are targeted request-level measurements, not a storefront percentage claim. WordPress object caching kept database query counts low in both states; the evidence is the repeated-call reduction and cache-hit behavior.

## Free tier boundary

- Keeps the existing Free field, fee, upload, add-on, input-field, order-number, and invoice capabilities useful.
- Does not unlock paid field counts, multiple uploads, advanced conditions/rule combinations, gallery/file controls, or premium settings.
- Manually crafted tier-boundary attempts were included in Docker validation.

## Validation evidence

Environment: WordPress 6.9, WooCommerce 10.8.1, PHP 8.2, local Docker.

- Final targeted runtime matrix after source sync: Free HPOS off **PASS**, Free HPOS on **PASS**.
- Full browser/UI suite: **31 pass, 0 fail** (32 results including one informational pre-existing log-noise item).
- Classic and Blocks guest checkout, logged-in Blocks checkout, cart fees/recalculation, valid/invalid field rules, order meta, thank-you display, admin order display, and Free boundary attempts passed.
- Customer account display, customer email display, PDF generation, and PDF attachment passed.
- Order-number tracking and historical invoice report checks passed with HPOS off/on.
- Version/activation surface reports 8.1.0.
- `php -l` passed for every changed PHP file; `git diff --check` passed.
- Static scans reviewed new direct order-meta access and request/file handling. Added direct order meta is limited to documented legacy or product-meta paths.
- Final debug-log scan found no fatal, parse, uncaught, or memory errors.

## Known limitations

- Cart-aware Blocks field visibility requires WooCommerce 9.9+; older supported versions omit conditioned fields rather than rendering them incorrectly.
- Plugin Check was not installed in the existing Docker environments, so it was not run.
- Docker logs retain pre-existing WP_DEBUG redefinition and early text-domain notice/warning noise; no new fatal errors were observed.
- No staging or production deployment is part of this PR.

## QA checklist

- [ ] Install and activate the Free build; confirm all version surfaces show 8.1.0.
- [ ] Repeat Classic Checkout and Checkout Blocks as guest and logged-in customer.
- [ ] Verify supported field types, required/invalid input, visibility rules, order/admin/account/email output.
- [ ] Confirm simple fees in Blocks and checkout-field-conditional fees only in Classic Checkout.
- [ ] Test HPOS enabled and disabled, including Order Numbers, Checkout Files, PDF generation/reporting, and admin order screens.
- [ ] Confirm only one Free custom field/upload/input configuration is accepted, including crafted requests.
- [ ] Review public readme/changelog wording and all intentional Classic-only limits.
